### PR TITLE
docs: DeepWikiへのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Snampoプロジェクトのリポジトリです。
 
+> [!NOTE]
+> プロジェクトの詳細情報は <https://deepwiki.com/nakamaware/snampo> を参照してください。
+
 ## プロジェクト構成
 
 - `frontend/`: Flutterアプリケーション


### PR DESCRIPTION
## 概要

README.mdにDeepWikiへのリンクを追加しました。

## 変更内容

- README.mdの冒頭にDeepWikiへのリンクを含むNOTEブロックを追加
- プロジェクトの詳細情報へのアクセスを容易にするため

## 関連リンク

- DeepWiki: https://deepwiki.com/nakamaware/snampo