### PR TITLE
ユーザの座標がGetリクエストのクエリパラメータで送られている

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ import logging
 
 from fastapi import FastAPI, Query
 
-from app.models import RouteResponse, StreetViewImageResponse
+from app.models import RouteRequest, RouteResponse, StreetViewImageResponse
 from app.services.route_service import generate_route, get_street_view_image_data
 
 # Configure logging
@@ -86,40 +86,14 @@ def get_street_view_image(
     return get_street_view_image_data(latitude, longitude, size)
 
 
-@app.get("/route")
-def route(
-    current_lat: float = Query(
-        ...,
-        alias="currentLat",
-        description="現在地の緯度",
-        ge=-90,
-        le=90,
-        example=35.6762,
-    ),
-    current_lng: float = Query(
-        ...,
-        alias="currentLng",
-        description="現在地の経度",
-        ge=-180,
-        le=180,
-        example=139.6503,
-    ),
-    radius: float = Query(
-        ...,
-        description="目的地を生成する半径 (メートル単位)",
-        gt=0,
-        le=40075000,  # 地球の赤道一周の長さ (メートル)
-        example=5000,
-    ),
-) -> RouteResponse:
+@app.post("/route")
+def route(request: RouteRequest) -> RouteResponse:
     """ルートを生成
 
     Args:
-        current_lat: 現在の緯度
-        current_lng: 現在の経度
-        radius: 半径 (メートル単位)
+        request: ルート生成リクエスト(現在地の緯度・経度、半径を含む)
 
     Returns:
         RouteResponse: ルート情報
     """
-    return generate_route(current_lat, current_lng, radius)
+    return generate_route(request.current_lat, request.current_lng, request.radius)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -3,7 +3,7 @@
 APIレスポンス用のデータモデルを定義します。
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.value_objects import Latitude, Longitude
 
@@ -33,6 +33,32 @@ class StreetViewImageResponse(BaseModel):
     original_latitude: Latitude
     original_longitude: Longitude
     image_data: str
+
+
+class RouteRequest(BaseModel):
+    """ルート生成リクエストを表すモデル"""
+
+    current_lat: float = Field(
+        ...,
+        description="現在地の緯度",
+        ge=-90,
+        le=90,
+        example=35.6762,
+    )
+    current_lng: float = Field(
+        ...,
+        description="現在地の経度",
+        ge=-180,
+        le=180,
+        example=139.6503,
+    )
+    radius: float = Field(
+        ...,
+        description="目的地を生成する半径 (メートル単位)",
+        gt=0,
+        le=40075000,  # 地球の赤道一周の長さ (メートル)
+        example=5000,
+    )
 
 
 class RouteResponse(BaseModel):

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -78,54 +78,20 @@
       }
     },
     "/route": {
-      "get": {
+      "post": {
         "summary": "Route",
-        "description": "ルートを生成\n\nArgs:\n    current_lat: 現在の緯度\n    current_lng: 現在の経度\n    radius: 半径 (メートル単位)\n\nReturns:\n    RouteResponse: ルート情報",
-        "operationId": "route_route_get",
-        "parameters": [
-          {
-            "name": "currentLat",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "number",
-              "maximum": 90,
-              "minimum": -90,
-              "description": "現在地の緯度",
-              "title": "Currentlat"
-            },
-            "description": "現在地の緯度",
-            "example": 35.6762
+        "description": "ルートを生成\n\nArgs:\n    request: ルート生成リクエスト(現在地の緯度・経度、半径を含む)\n\nReturns:\n    RouteResponse: ルート情報",
+        "operationId": "route_route_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RouteRequest"
+              }
+            }
           },
-          {
-            "name": "currentLng",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "number",
-              "maximum": 180,
-              "minimum": -180,
-              "description": "現在地の経度",
-              "title": "Currentlng"
-            },
-            "description": "現在地の経度",
-            "example": 139.6503
-          },
-          {
-            "name": "radius",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "number",
-              "maximum": 40075000,
-              "exclusiveMinimum": 0,
-              "description": "目的地を生成する半径 (メートル単位)",
-              "title": "Radius"
-            },
-            "description": "目的地を生成する半径 (メートル単位)",
-            "example": 5000
-          }
-        ],
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -236,6 +202,42 @@
         ],
         "title": "Point",
         "description": "座標点を表すモデル"
+      },
+      "RouteRequest": {
+        "properties": {
+          "current_lat": {
+            "type": "number",
+            "maximum": 90.0,
+            "minimum": -90.0,
+            "title": "Current Lat",
+            "description": "現在地の緯度",
+            "example": 35.6762
+          },
+          "current_lng": {
+            "type": "number",
+            "maximum": 180.0,
+            "minimum": -180.0,
+            "title": "Current Lng",
+            "description": "現在地の経度",
+            "example": 139.6503
+          },
+          "radius": {
+            "type": "number",
+            "maximum": 40075000.0,
+            "exclusiveMinimum": 0.0,
+            "title": "Radius",
+            "description": "目的地を生成する半径 (メートル単位)",
+            "example": 5000
+          }
+        },
+        "type": "object",
+        "required": [
+          "current_lat",
+          "current_lng",
+          "radius"
+        ],
+        "title": "RouteRequest",
+        "description": "ルート生成リクエストを表すモデル"
       },
       "RouteResponse": {
         "properties": {

--- a/frontend/lib/repositories/mission_repository.dart
+++ b/frontend/lib/repositories/mission_repository.dart
@@ -23,15 +23,17 @@ class MissionRepository {
     required double currentLat,
     required double currentLng,
   }) async {
-    final radiusString =
-        (radius * 1000).toInt().toString(); // km から m にし整数値の文字列に
+    final radiusInMeters = radius * 1000; // km から m に変換
+
+    // リクエストボディを作成
+    final request = generated.RouteRequest(
+      currentLat: currentLat,
+      currentLng: currentLng,
+      radius: radiusInMeters,
+    );
 
     // 生成されたAPIクライアントを直接使用
-    final response = await _generatedApi.routeRouteGet(
-      currentLat,
-      currentLng,
-      double.parse(radiusString),
-    );
+    final response = await _generatedApi.routeRoutePost(request);
 
     if (response == null) {
       throw Exception('APIレスポンスがnullです');

--- a/packages/snampo_api/.openapi-generator/FILES
+++ b/packages/snampo_api/.openapi-generator/FILES
@@ -7,6 +7,7 @@ doc/DefaultApi.md
 doc/HTTPValidationError.md
 doc/MidPoint.md
 doc/Point.md
+doc/RouteRequest.md
 doc/RouteResponse.md
 doc/StreetViewImageResponse.md
 doc/ValidationError.md
@@ -24,6 +25,7 @@ lib/auth/oauth.dart
 lib/model/http_validation_error.dart
 lib/model/mid_point.dart
 lib/model/point.dart
+lib/model/route_request.dart
 lib/model/route_response.dart
 lib/model/street_view_image_response.dart
 lib/model/validation_error.dart
@@ -32,6 +34,7 @@ test/default_api_test.dart
 test/http_validation_error_test.dart
 test/mid_point_test.dart
 test/point_test.dart
+test/route_request_test.dart
 test/route_response_test.dart
 test/street_view_image_response_test.dart
 test/validation_error_test.dart

--- a/packages/snampo_api/README.md
+++ b/packages/snampo_api/README.md
@@ -61,7 +61,7 @@ All URIs are relative to *http://localhost*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *DefaultApi* | [**getStreetViewImageStreetviewGet**](doc//DefaultApi.md#getstreetviewimagestreetviewget) | **GET** /streetview | Get Street View Image
-*DefaultApi* | [**routeRouteGet**](doc//DefaultApi.md#routerouteget) | **GET** /route | Route
+*DefaultApi* | [**routeRoutePost**](doc//DefaultApi.md#routeroutepost) | **POST** /route | Route
 
 
 ## Documentation For Models
@@ -69,6 +69,7 @@ Class | Method | HTTP request | Description
  - [HTTPValidationError](doc//HTTPValidationError.md)
  - [MidPoint](doc//MidPoint.md)
  - [Point](doc//Point.md)
+ - [RouteRequest](doc//RouteRequest.md)
  - [RouteResponse](doc//RouteResponse.md)
  - [StreetViewImageResponse](doc//StreetViewImageResponse.md)
  - [ValidationError](doc//ValidationError.md)

--- a/packages/snampo_api/doc/DefaultApi.md
+++ b/packages/snampo_api/doc/DefaultApi.md
@@ -10,7 +10,7 @@ All URIs are relative to *http://localhost*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**getStreetViewImageStreetviewGet**](DefaultApi.md#getstreetviewimagestreetviewget) | **GET** /streetview | Get Street View Image
-[**routeRouteGet**](DefaultApi.md#routerouteget) | **GET** /route | Route
+[**routeRoutePost**](DefaultApi.md#routeroutepost) | **POST** /route | Route
 
 
 # **getStreetViewImageStreetviewGet**
@@ -60,27 +60,25 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **routeRouteGet**
-> RouteResponse routeRouteGet(currentLat, currentLng, radius)
+# **routeRoutePost**
+> RouteResponse routeRoutePost(routeRequest)
 
 Route
 
-ルートを生成  Args:     current_lat: 現在の緯度     current_lng: 現在の経度     radius: 半径 (メートル単位)  Returns:     RouteResponse: ルート情報
+ルートを生成  Args:     request: ルート生成リクエスト(現在地の緯度・経度、半径を含む)  Returns:     RouteResponse: ルート情報
 
 ### Example
 ```dart
 import 'package:snampo_api/api.dart';
 
 final api_instance = DefaultApi();
-final currentLat = 35.6762; // num | 現在地の緯度
-final currentLng = 139.6503; // num | 現在地の経度
-final radius = 5000; // num | 目的地を生成する半径 (メートル単位)
+final routeRequest = RouteRequest(); // RouteRequest | 
 
 try {
-    final result = api_instance.routeRouteGet(currentLat, currentLng, radius);
+    final result = api_instance.routeRoutePost(routeRequest);
     print(result);
 } catch (e) {
-    print('Exception when calling DefaultApi->routeRouteGet: $e\n');
+    print('Exception when calling DefaultApi->routeRoutePost: $e\n');
 }
 ```
 
@@ -88,9 +86,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **currentLat** | **num**| 現在地の緯度 | 
- **currentLng** | **num**| 現在地の経度 | 
- **radius** | **num**| 目的地を生成する半径 (メートル単位) | 
+ **routeRequest** | [**RouteRequest**](RouteRequest.md)|  | 
 
 ### Return type
 
@@ -102,7 +98,7 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/json
  - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/packages/snampo_api/doc/RouteRequest.md
+++ b/packages/snampo_api/doc/RouteRequest.md
@@ -1,0 +1,17 @@
+# snampo_api.model.RouteRequest
+
+## Load the model package
+```dart
+import 'package:snampo_api/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**currentLat** | **num** | 現在地の緯度 | 
+**currentLng** | **num** | 現在地の経度 | 
+**radius** | **num** | 目的地を生成する半径 (メートル単位) | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/packages/snampo_api/lib/api.dart
+++ b/packages/snampo_api/lib/api.dart
@@ -33,6 +33,7 @@ part 'api/default_api.dart';
 part 'model/http_validation_error.dart';
 part 'model/mid_point.dart';
 part 'model/point.dart';
+part 'model/route_request.dart';
 part 'model/route_response.dart';
 part 'model/street_view_image_response.dart';
 part 'model/validation_error.dart';

--- a/packages/snampo_api/lib/api/default_api.dart
+++ b/packages/snampo_api/lib/api/default_api.dart
@@ -94,41 +94,30 @@ class DefaultApi {
 
   /// Route
   ///
-  /// ルートを生成  Args:     current_lat: 現在の緯度     current_lng: 現在の経度     radius: 半径 (メートル単位)  Returns:     RouteResponse: ルート情報
+  /// ルートを生成  Args:     request: ルート生成リクエスト(現在地の緯度・経度、半径を含む)  Returns:     RouteResponse: ルート情報
   ///
   /// Note: This method returns the HTTP [Response].
   ///
   /// Parameters:
   ///
-  /// * [num] currentLat (required):
-  ///   現在地の緯度
-  ///
-  /// * [num] currentLng (required):
-  ///   現在地の経度
-  ///
-  /// * [num] radius (required):
-  ///   目的地を生成する半径 (メートル単位)
-  Future<Response> routeRouteGetWithHttpInfo(num currentLat, num currentLng, num radius,) async {
+  /// * [RouteRequest] routeRequest (required):
+  Future<Response> routeRoutePostWithHttpInfo(RouteRequest routeRequest,) async {
     // ignore: prefer_const_declarations
     final path = r'/route';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? postBody = routeRequest;
 
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('', 'currentLat', currentLat));
-      queryParams.addAll(_queryParams('', 'currentLng', currentLng));
-      queryParams.addAll(_queryParams('', 'radius', radius));
-
-    const contentTypes = <String>[];
+    const contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
       path,
-      'GET',
+      'POST',
       queryParams,
       postBody,
       headerParams,
@@ -139,20 +128,13 @@ class DefaultApi {
 
   /// Route
   ///
-  /// ルートを生成  Args:     current_lat: 現在の緯度     current_lng: 現在の経度     radius: 半径 (メートル単位)  Returns:     RouteResponse: ルート情報
+  /// ルートを生成  Args:     request: ルート生成リクエスト(現在地の緯度・経度、半径を含む)  Returns:     RouteResponse: ルート情報
   ///
   /// Parameters:
   ///
-  /// * [num] currentLat (required):
-  ///   現在地の緯度
-  ///
-  /// * [num] currentLng (required):
-  ///   現在地の経度
-  ///
-  /// * [num] radius (required):
-  ///   目的地を生成する半径 (メートル単位)
-  Future<RouteResponse?> routeRouteGet(num currentLat, num currentLng, num radius,) async {
-    final response = await routeRouteGetWithHttpInfo(currentLat, currentLng, radius,);
+  /// * [RouteRequest] routeRequest (required):
+  Future<RouteResponse?> routeRoutePost(RouteRequest routeRequest,) async {
+    final response = await routeRoutePostWithHttpInfo(routeRequest,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/packages/snampo_api/lib/api_client.dart
+++ b/packages/snampo_api/lib/api_client.dart
@@ -188,6 +188,8 @@ class ApiClient {
           return MidPoint.fromJson(value);
         case 'Point':
           return Point.fromJson(value);
+        case 'RouteRequest':
+          return RouteRequest.fromJson(value);
         case 'RouteResponse':
           return RouteResponse.fromJson(value);
         case 'StreetViewImageResponse':

--- a/packages/snampo_api/lib/model/route_request.dart
+++ b/packages/snampo_api/lib/model/route_request.dart
@@ -1,0 +1,136 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class RouteRequest {
+  /// Returns a new [RouteRequest] instance.
+  RouteRequest({
+    required this.currentLat,
+    required this.currentLng,
+    required this.radius,
+  });
+
+  /// 現在地の緯度
+  ///
+  /// Minimum value: -90.0
+  /// Maximum value: 90.0
+  num currentLat;
+
+  /// 現在地の経度
+  ///
+  /// Minimum value: -180.0
+  /// Maximum value: 180.0
+  num currentLng;
+
+  /// 目的地を生成する半径 (メートル単位)
+  ///
+  /// Maximum value: 40075000
+  num radius;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is RouteRequest &&
+    other.currentLat == currentLat &&
+    other.currentLng == currentLng &&
+    other.radius == radius;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (currentLat.hashCode) +
+    (currentLng.hashCode) +
+    (radius.hashCode);
+
+  @override
+  String toString() => 'RouteRequest[currentLat=$currentLat, currentLng=$currentLng, radius=$radius]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+      json[r'current_lat'] = this.currentLat;
+      json[r'current_lng'] = this.currentLng;
+      json[r'radius'] = this.radius;
+    return json;
+  }
+
+  /// Returns a new [RouteRequest] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static RouteRequest? fromJson(dynamic value) {
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      // Ensure that the map contains the required keys.
+      // Note 1: the values aren't checked for validity beyond being non-null.
+      // Note 2: this code is stripped in release mode!
+      assert(() {
+        requiredKeys.forEach((key) {
+          assert(json.containsKey(key), 'Required key "RouteRequest[$key]" is missing from JSON.');
+          assert(json[key] != null, 'Required key "RouteRequest[$key]" has a null value in JSON.');
+        });
+        return true;
+      }());
+
+      return RouteRequest(
+        currentLat: num.parse('${json[r'current_lat']}'),
+        currentLng: num.parse('${json[r'current_lng']}'),
+        radius: num.parse('${json[r'radius']}'),
+      );
+    }
+    return null;
+  }
+
+  static List<RouteRequest> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <RouteRequest>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = RouteRequest.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, RouteRequest> mapFromJson(dynamic json) {
+    final map = <String, RouteRequest>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = RouteRequest.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of RouteRequest-objects as value to a dart map
+  static Map<String, List<RouteRequest>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<RouteRequest>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = RouteRequest.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+    'current_lat',
+    'current_lng',
+    'radius',
+  };
+}
+

--- a/packages/snampo_api/test/default_api_test.dart
+++ b/packages/snampo_api/test/default_api_test.dart
@@ -28,10 +28,10 @@ void main() {
 
     // Route
     //
-    // ルートを生成  Args:     current_lat: 現在の緯度     current_lng: 現在の経度     radius: 半径 (メートル単位)  Returns:     RouteResponse: ルート情報
+    // ルートを生成  Args:     request: ルート生成リクエスト(現在地の緯度・経度、半径を含む)  Returns:     RouteResponse: ルート情報
     //
-    //Future<RouteResponse> routeRouteGet(num currentLat, num currentLng, num radius) async
-    test('test routeRouteGet', () async {
+    //Future<RouteResponse> routeRoutePost(RouteRequest routeRequest) async
+    test('test routeRoutePost', () async {
       // TODO
     });
 

--- a/packages/snampo_api/test/route_request_test.dart
+++ b/packages/snampo_api/test/route_request_test.dart
@@ -1,0 +1,40 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:snampo_api/api.dart';
+import 'package:test/test.dart';
+
+// tests for RouteRequest
+void main() {
+  // final instance = RouteRequest();
+
+  group('test RouteRequest', () {
+    // 現在地の緯度
+    // num currentLat
+    test('to test the property `currentLat`', () async {
+      // TODO
+    });
+
+    // 現在地の経度
+    // num currentLng
+    test('to test the property `currentLng`', () async {
+      // TODO
+    });
+
+    // 目的地を生成する半径 (メートル単位)
+    // num radius
+    test('to test the property `radius`', () async {
+      // TODO
+    });
+
+
+  });
+
+}


### PR DESCRIPTION
## 概要
ユーザの座標がGETリクエストのクエリパラメータで送られており、セキュリティ上の問題があったため、POSTリクエストのボディで送るように変更しました。

## 変更内容
- `backend/app/models.py` に `RouteRequest` モデルを追加
- `backend/app/main.py` の `/route` エンドポイントをGETからPOSTに変更し、リクエストボディを使用するように修正
- OpenAPIスキーマとDart APIクライアントを再生成
- `frontend/lib/repositories/mission_repository.dart` でPOSTリクエストを使用するように変更

## 影響範囲
- [x] バックエンド
- [x] フロントエンド

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ルート生成APIで新しいRouteRequestモデルが利用可能になりました。

* **API変更**
  * /routeエンドポイントがGET方式からPOST方式に変更されました。
  * 個別のクエリパラメータ（latitude、longitude、radius）をリクエストボディのRouteRequestオブジェクトで送信するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->