### PR TITLE
履歴画面を追加

### DIFF
--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:snampo/presentation/pages/history_detail_page.dart';
+import 'package:snampo/presentation/pages/history_list_page.dart';
 import 'package:snampo/presentation/pages/home_page.dart';
 import 'package:snampo/presentation/pages/mission_page.dart';
 import 'package:snampo/presentation/pages/result_page.dart';
@@ -54,6 +56,17 @@ final GoRouter _router = GoRouter(
     GoRoute(
       path: '/result',
       builder: (context, state) => const ResultPage(),
+    ),
+    GoRoute(
+      path: '/history',
+      builder: (context, state) => const HistoryListPage(),
+    ),
+    GoRoute(
+      path: '/history/:id',
+      builder: (context, state) {
+        final id = state.pathParameters['id']!;
+        return HistoryDetailPage(historyId: id);
+      },
     ),
   ],
 );

--- a/frontend/lib/models/walk_history.dart
+++ b/frontend/lib/models/walk_history.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+
+import 'package:snampo/models/game_session.dart';
+import 'package:snampo/models/location_entity.dart';
+import 'package:snampo/utils/distance_calculator.dart';
+
+/// 散歩履歴を表すエンティティ
+class WalkHistory {
+  /// WalkHistoryのコンストラクタ
+  WalkHistory({
+    required this.id,
+    required this.completedAt,
+    required this.distanceMeters,
+    required this.overviewPolyline,
+    required this.photoPaths,
+    required this.destination,
+    required this.midpoints,
+  });
+
+  /// GameSessionからWalkHistoryを生成する
+  ///
+  /// [session] は完了したゲームセッション
+  /// セッションが完了していない場合は例外を投げる
+  factory WalkHistory.fromGameSession(GameSession session) {
+    if (session.status != GameStatus.completed) {
+      throw ArgumentError('セッションが完了していません');
+    }
+
+    final distanceMeters = DistanceCalculator.calculateDistanceFromPolyline(
+      session.locationEntity.overviewPolyline,
+    );
+
+    return WalkHistory(
+      id: _generateId(session.startedAt),
+      completedAt: DateTime.now(),
+      distanceMeters: distanceMeters,
+      overviewPolyline: session.locationEntity.overviewPolyline,
+      photoPaths: List<String?>.from(session.photoPaths),
+      destination: session.locationEntity.destination,
+      midpoints: List<MidPointEntity>.from(session.locationEntity.midpoints),
+    );
+  }
+
+  /// JSONからWalkHistoryを生成する
+  factory WalkHistory.fromJson(Map<String, dynamic> json) {
+    final completedAtString = json['completedAt'] as String;
+    final completedAt = DateTime.tryParse(completedAtString);
+    if (completedAt == null) {
+      throw FormatException('Invalid DateTime format: $completedAtString');
+    }
+
+    final photoPaths = (json['photoPaths'] as List<dynamic>?)
+            ?.map((e) => e as String?)
+            .toList() ??
+        [];
+
+    final midpoints = (json['midpoints'] as List<dynamic>?)
+            ?.map((e) => MidPointEntity.fromJson(e as Map<String, dynamic>))
+            .toList() ??
+        [];
+
+    return WalkHistory(
+      id: json['id'] as String,
+      completedAt: completedAt,
+      distanceMeters: (json['distanceMeters'] as num).toDouble(),
+      overviewPolyline: json['overviewPolyline'] as String?,
+      photoPaths: photoPaths,
+      destination: json['destination'] != null
+          ? MidPointEntity.fromJson(
+              json['destination'] as Map<String, dynamic>,
+            )
+          : null,
+      midpoints: midpoints,
+    );
+  }
+
+  /// JSON文字列からWalkHistoryを生成する
+  static WalkHistory? fromJsonString(String? jsonString) {
+    if (jsonString == null) return null;
+    try {
+      return WalkHistory.fromJson(
+        jsonDecode(jsonString) as Map<String, dynamic>,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// ユニークIDを生成する
+  static String _generateId(DateTime startedAt) {
+    final startMs = startedAt.millisecondsSinceEpoch;
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    return '${startMs}_$nowMs';
+  }
+
+  /// 履歴のID
+  final String id;
+
+  /// 完了日時
+  final DateTime completedAt;
+
+  /// 総距離 (メートル単位)
+  final double distanceMeters;
+
+  /// ルートのポリライン文字列
+  final String? overviewPolyline;
+
+  /// 各スポットの写真パスのリスト
+  /// インデックス0がmidpoints[0]、インデックス1がdestinationに対応
+  final List<String?> photoPaths;
+
+  /// 目的地
+  final MidPointEntity? destination;
+
+  /// 中間地点のリスト
+  final List<MidPointEntity> midpoints;
+
+  /// WalkHistoryをJSONに変換する
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'completedAt': completedAt.toIso8601String(),
+      'distanceMeters': distanceMeters,
+      'overviewPolyline': overviewPolyline,
+      'photoPaths': photoPaths,
+      'destination': destination?.toJson(),
+      'midpoints': midpoints.map((e) => e.toJson()).toList(),
+    };
+  }
+
+  /// WalkHistoryをJSON文字列に変換する
+  String toJsonString() => jsonEncode(toJson());
+
+  /// 距離をキロメートル単位で取得する
+  double get distanceKilometers => distanceMeters / 1000.0;
+
+  /// 指定されたインデックスの写真パスを取得する
+  String? getPhotoPath(int index) {
+    if (index < 0 || index >= photoPaths.length) return null;
+    return photoPaths[index];
+  }
+}

--- a/frontend/lib/presentation/controllers/walk_history_controller.dart
+++ b/frontend/lib/presentation/controllers/walk_history_controller.dart
@@ -1,0 +1,94 @@
+import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:snampo/models/walk_history.dart';
+import 'package:snampo/repositories/walk_history_repository.dart';
+
+part 'walk_history_controller.g.dart';
+
+/// 散歩履歴リポジトリのプロバイダー
+@riverpod
+WalkHistoryRepository walkHistoryRepository(Ref ref) {
+  return WalkHistoryRepository();
+}
+
+/// 散歩履歴を管理するコントローラー
+@riverpod
+class WalkHistoryController extends _$WalkHistoryController {
+  @override
+  Future<List<WalkHistory>> build() async {
+    final repository = ref.read(walkHistoryRepositoryProvider);
+    return repository.getAllHistories();
+  }
+
+  /// 履歴を追加する
+  ///
+  /// [history] は追加する履歴
+  Future<void> addHistory(WalkHistory history) async {
+    state = const AsyncValue.loading();
+    try {
+      final repository = ref.read(walkHistoryRepositoryProvider);
+      await repository.saveHistory(history);
+      // 状態を更新
+      final histories = await repository.getAllHistories();
+      state = AsyncValue.data(histories);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// 指定されたIDの履歴を取得する
+  ///
+  /// [id] は履歴のID
+  Future<WalkHistory?> getHistoryById(String id) async {
+    try {
+      final repository = ref.read(walkHistoryRepositoryProvider);
+      return repository.getHistoryById(id);
+    } catch (e) {
+      // エラーが発生した場合は再スロー
+      // 呼び出し側でエラーハンドリングを行う
+      rethrow;
+    }
+  }
+
+  /// 指定されたIDの履歴を削除する
+  ///
+  /// [id] は削除する履歴のID
+  Future<void> deleteHistory(String id) async {
+    state = const AsyncValue.loading();
+    try {
+      final repository = ref.read(walkHistoryRepositoryProvider);
+      await repository.deleteHistory(id);
+      // 状態を更新
+      final histories = await repository.getAllHistories();
+      state = AsyncValue.data(histories);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// すべての履歴を削除する
+  Future<void> clearAllHistories() async {
+    state = const AsyncValue.loading();
+    try {
+      final repository = ref.read(walkHistoryRepositoryProvider);
+      await repository.clearAllHistories();
+      // 状態を更新
+      final histories = await repository.getAllHistories();
+      state = AsyncValue.data(histories);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// 履歴リストを再読み込みする
+  Future<void> refresh() async {
+    state = const AsyncValue.loading();
+    try {
+      final repository = ref.read(walkHistoryRepositoryProvider);
+      final histories = await repository.getAllHistories();
+      state = AsyncValue.data(histories);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+}

--- a/frontend/lib/presentation/controllers/walk_history_controller.g.dart
+++ b/frontend/lib/presentation/controllers/walk_history_controller.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'walk_history_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$walkHistoryRepositoryHash() =>
+    r'575dc4a2e4ab6d4d8ef89dbf0ac00080261352a8';
+
+/// 散歩履歴リポジトリのプロバイダー
+///
+/// Copied from [walkHistoryRepository].
+@ProviderFor(walkHistoryRepository)
+final walkHistoryRepositoryProvider =
+    AutoDisposeProvider<WalkHistoryRepository>.internal(
+  walkHistoryRepository,
+  name: r'walkHistoryRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$walkHistoryRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef WalkHistoryRepositoryRef
+    = AutoDisposeProviderRef<WalkHistoryRepository>;
+String _$walkHistoryControllerHash() =>
+    r'c170ccabb015a9c478016b388f981adb564d4582';
+
+/// 散歩履歴を管理するコントローラー
+///
+/// Copied from [WalkHistoryController].
+@ProviderFor(WalkHistoryController)
+final walkHistoryControllerProvider = AutoDisposeAsyncNotifierProvider<
+    WalkHistoryController, List<WalkHistory>>.internal(
+  WalkHistoryController.new,
+  name: r'walkHistoryControllerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$walkHistoryControllerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$WalkHistoryController = AutoDisposeAsyncNotifier<List<WalkHistory>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/frontend/lib/presentation/pages/history_detail_page.dart
+++ b/frontend/lib/presentation/pages/history_detail_page.dart
@@ -1,0 +1,466 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_polyline_points/flutter_polyline_points.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:snampo/models/walk_history.dart';
+import 'package:snampo/presentation/controllers/walk_history_controller.dart';
+
+/// 履歴詳細を表示するページ
+class HistoryDetailPage extends ConsumerWidget {
+  /// HistoryDetailPageのコンストラクタ
+  const HistoryDetailPage({
+    required this.historyId,
+    super.key,
+  });
+
+  /// 履歴ID
+  final String historyId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final titleTextStyle = (theme.textTheme.displayMedium ??
+            theme.textTheme.headlineMedium ??
+            const TextStyle())
+        .copyWith(
+      color: theme.colorScheme.onPrimary,
+    );
+
+    final historyAsync = ref.watch(
+      walkHistoryControllerProvider.select(
+        (histories) => histories.whenData(
+          (histories) => histories.firstWhere(
+            (h) => h.id == historyId,
+            orElse: () => throw StateError('履歴が見つかりません'),
+          ),
+        ),
+      ),
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          '履歴詳細',
+          style: titleTextStyle,
+        ),
+        centerTitle: true,
+        backgroundColor: theme.colorScheme.primary,
+      ),
+      body: historyAsync.when(
+        data: (history) => HistoryDetailContent(history: history),
+        loading: () => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        error: (error, stackTrace) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline, size: 64),
+              const SizedBox(height: 16),
+              Text(
+                '履歴の読み込みに失敗しました',
+                style: theme.textTheme.bodyLarge,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 履歴詳細コンテンツウィジェット
+class HistoryDetailContent extends StatefulWidget {
+  /// HistoryDetailContentのコンストラクタ
+  const HistoryDetailContent({
+    required this.history,
+    super.key,
+  });
+
+  /// 履歴データ
+  final WalkHistory history;
+
+  @override
+  State<HistoryDetailContent> createState() => _HistoryDetailContentState();
+}
+
+/// HistoryDetailContentの状態管理クラス
+class _HistoryDetailContentState extends State<HistoryDetailContent> {
+  GoogleMapController? _mapController;
+  List<LatLng> _polylineCoordinates = [];
+  final Set<Polyline> _polylines = {};
+  final Set<Marker> _markers = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _decodePolyline();
+  }
+
+  @override
+  void dispose() {
+    _mapController?.dispose();
+    _polylines.clear();
+    _markers.clear();
+    _polylineCoordinates.clear();
+    super.dispose();
+  }
+
+  void _decodePolyline() {
+    final polyline = widget.history.overviewPolyline;
+    if (polyline == null || polyline.isEmpty) return;
+
+    try {
+      final points = PolylinePoints().decodePolyline(polyline);
+      if (points.isEmpty) return;
+
+      setState(() {
+        _polylineCoordinates = points
+            .map((point) => LatLng(point.latitude, point.longitude))
+            .toList();
+
+        _polylines.add(
+          Polyline(
+            polylineId: const PolylineId('route'),
+            points: _polylineCoordinates,
+            color: Colors.blue,
+            width: 5,
+          ),
+        );
+      });
+
+      // ポリラインのデコードが完了したらマーカーを設定
+      _setupMarkers();
+
+      // マップの範囲に合わせてカメラを調整
+      if (_mapController != null && _polylineCoordinates.isNotEmpty) {
+        _fitBounds();
+      }
+    } catch (_) {
+      // ポリラインのデコードに失敗した場合は無視
+    }
+  }
+
+  void _setupMarkers() {
+    final markers = <Marker>{};
+
+    // 出発地点 (最初のポイント)
+    if (_polylineCoordinates.isNotEmpty) {
+      final startPoint = _polylineCoordinates.first;
+      markers.add(
+        Marker(
+          markerId: const MarkerId('start'),
+          position: startPoint,
+          icon: BitmapDescriptor.defaultMarkerWithHue(
+            BitmapDescriptor.hueGreen,
+          ),
+          infoWindow: const InfoWindow(title: '出発地点'),
+        ),
+      );
+    }
+
+    // 目的地
+    if (widget.history.destination != null &&
+        widget.history.destination!.latitude != null &&
+        widget.history.destination!.longitude != null) {
+      markers.add(
+        Marker(
+          markerId: const MarkerId('destination'),
+          position: LatLng(
+            widget.history.destination!.latitude!,
+            widget.history.destination!.longitude!,
+          ),
+          icon: BitmapDescriptor.defaultMarkerWithHue(
+            BitmapDescriptor.hueRed,
+          ),
+          infoWindow: const InfoWindow(title: '目的地'),
+        ),
+      );
+    }
+
+    // 中間地点
+    for (var i = 0; i < widget.history.midpoints.length; i++) {
+      final midpoint = widget.history.midpoints[i];
+      if (midpoint.latitude != null && midpoint.longitude != null) {
+        markers.add(
+          Marker(
+            markerId: MarkerId('midpoint_$i'),
+            position: LatLng(
+              midpoint.latitude!,
+              midpoint.longitude!,
+            ),
+            icon: BitmapDescriptor.defaultMarkerWithHue(
+              BitmapDescriptor.hueBlue,
+            ),
+            infoWindow: InfoWindow(title: '中間地点 ${i + 1}'),
+          ),
+        );
+      }
+    }
+
+    setState(() {
+      _markers.addAll(markers);
+    });
+  }
+
+  void _fitBounds() {
+    if (_polylineCoordinates.isEmpty || _mapController == null) return;
+
+    var minLat = _polylineCoordinates.first.latitude;
+    var maxLat = _polylineCoordinates.first.latitude;
+    var minLng = _polylineCoordinates.first.longitude;
+    var maxLng = _polylineCoordinates.first.longitude;
+
+    for (final point in _polylineCoordinates) {
+      if (point.latitude < minLat) minLat = point.latitude;
+      if (point.latitude > maxLat) maxLat = point.latitude;
+      if (point.longitude < minLng) minLng = point.longitude;
+      if (point.longitude > maxLng) maxLng = point.longitude;
+    }
+
+    _mapController!.animateCamera(
+      CameraUpdate.newLatLngBounds(
+        LatLngBounds(
+          southwest: LatLng(minLat, minLng),
+          northeast: LatLng(maxLat, maxLng),
+        ),
+        100,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateText = _formatDate(widget.history.completedAt);
+    final distanceText = widget.history.distanceKilometers >= 1
+        ? '${widget.history.distanceKilometers.toStringAsFixed(2)} km'
+        : '${widget.history.distanceMeters.toStringAsFixed(0)} m';
+
+    // 初期カメラ位置を決定
+    LatLng initialPosition;
+    if (_polylineCoordinates.isNotEmpty) {
+      initialPosition = _polylineCoordinates.first;
+    } else if (widget.history.destination != null &&
+        widget.history.destination!.latitude != null &&
+        widget.history.destination!.longitude != null) {
+      initialPosition = LatLng(
+        widget.history.destination!.latitude!,
+        widget.history.destination!.longitude!,
+      );
+    } else {
+      initialPosition = const LatLng(35.6812, 139.7671); // 東京駅
+    }
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 地図
+          SizedBox(
+            height: 300,
+            child: GoogleMap(
+              initialCameraPosition: CameraPosition(
+                target: initialPosition,
+                zoom: 14,
+              ),
+              polylines: _polylines,
+              markers: _markers,
+              myLocationButtonEnabled: false,
+              zoomControlsEnabled: false,
+              onMapCreated: (controller) {
+                _mapController = controller;
+                if (_polylineCoordinates.isNotEmpty) {
+                  _fitBounds();
+                }
+              },
+            ),
+          ),
+          // 情報セクション
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 日付
+                Row(
+                  children: [
+                    Icon(
+                      Icons.calendar_today,
+                      size: 20,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      dateText,
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                // 距離
+                Row(
+                  children: [
+                    Icon(
+                      Icons.straighten,
+                      size: 20,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      distanceText,
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                // 写真セクション
+                if (_hasPhotos())
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '写真',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      _buildPhotoGallery(theme),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _hasPhotos() {
+    // 撮影した写真があるかチェック
+    if (widget.history.photoPaths.any((path) => path != null)) {
+      return true;
+    }
+    // ストリートビュー画像があるかチェック
+    if (widget.history.destination?.imageUtf8 != null) {
+      return true;
+    }
+    for (final midpoint in widget.history.midpoints) {
+      if (midpoint.imageUtf8 != null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Widget _buildPhotoGallery(ThemeData theme) {
+    final photos = <Widget>[];
+
+    // 撮影した写真を追加
+    for (var i = 0; i < widget.history.photoPaths.length; i++) {
+      final photoPath = widget.history.photoPaths[i];
+      if (photoPath != null) {
+        final file = File(photoPath);
+        if (file.existsSync()) {
+          photos.add(
+            _buildPhotoItem(
+              Image.file(file, fit: BoxFit.cover),
+              '撮影写真 ${i + 1}',
+            ),
+          );
+        }
+      }
+    }
+
+    // ストリートビュー画像を追加
+    if (widget.history.destination?.imageUtf8 != null) {
+      try {
+        final imageBytes = base64Decode(widget.history.destination!.imageUtf8!);
+        photos.add(
+          _buildPhotoItem(
+            Image.memory(
+              imageBytes,
+              fit: BoxFit.cover,
+            ),
+            '目的地のストリートビュー',
+          ),
+        );
+      } catch (_) {
+        // 画像の読み込みに失敗した場合は無視
+      }
+    }
+
+    for (var i = 0; i < widget.history.midpoints.length; i++) {
+      final midpoint = widget.history.midpoints[i];
+      if (midpoint.imageUtf8 != null) {
+        try {
+          final imageBytes = base64Decode(midpoint.imageUtf8!);
+          photos.add(
+            _buildPhotoItem(
+              Image.memory(
+                imageBytes,
+                fit: BoxFit.cover,
+              ),
+              '中間地点 ${i + 1} のストリートビュー',
+            ),
+          );
+        } catch (_) {
+          // 画像の読み込みに失敗した場合は無視
+        }
+      }
+    }
+
+    if (photos.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: photos,
+    );
+  }
+
+  Widget _buildPhotoItem(Widget image, String label) {
+    return SizedBox(
+      width: 150,
+      height: 150,
+      child: Column(
+        children: [
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: image,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall,
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 日付をフォーマットする
+  String _formatDate(DateTime date) {
+    final year = date.year;
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    final hour = date.hour.toString().padLeft(2, '0');
+    final minute = date.minute.toString().padLeft(2, '0');
+    return '$year年$month月$day日 $hour:$minute';
+  }
+}

--- a/frontend/lib/presentation/pages/history_list_page.dart
+++ b/frontend/lib/presentation/pages/history_list_page.dart
@@ -1,0 +1,223 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:snampo/models/walk_history.dart';
+import 'package:snampo/presentation/controllers/walk_history_controller.dart';
+
+/// 履歴一覧を表示するページ
+class HistoryListPage extends ConsumerWidget {
+  /// HistoryListPageのコンストラクタ
+  const HistoryListPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final titleTextStyle = (theme.textTheme.displayMedium ??
+            theme.textTheme.headlineMedium ??
+            const TextStyle())
+        .copyWith(
+      color: theme.colorScheme.onPrimary,
+    );
+
+    final historiesAsync = ref.watch(walkHistoryControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          '履歴',
+          style: titleTextStyle,
+        ),
+        centerTitle: true,
+        backgroundColor: theme.colorScheme.primary,
+      ),
+      body: historiesAsync.when(
+        data: (histories) {
+          if (histories.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.history,
+                    size: 64,
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    '履歴がありません',
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: () async {
+              await ref.read(walkHistoryControllerProvider.notifier).refresh();
+            },
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: histories.length,
+              itemBuilder: (context, index) {
+                final history = histories[index];
+                return HistoryCard(history: history);
+              },
+            ),
+          );
+        },
+        loading: () => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        error: (error, stackTrace) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline, size: 64),
+              const SizedBox(height: 16),
+              Text(
+                'エラーが発生しました',
+                style: theme.textTheme.bodyLarge,
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () {
+                  ref.invalidate(walkHistoryControllerProvider);
+                },
+                child: const Text('再読み込み'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 履歴カードウィジェット
+class HistoryCard extends StatelessWidget {
+  /// HistoryCardのコンストラクタ
+  const HistoryCard({
+    required this.history,
+    super.key,
+  });
+
+  /// 履歴データ
+  final WalkHistory history;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateText = _formatDate(history.completedAt);
+    final distanceText = history.distanceKilometers >= 1
+        ? '${history.distanceKilometers.toStringAsFixed(2)} km'
+        : '${history.distanceMeters.toStringAsFixed(0)} m';
+
+    // サムネイル画像を取得 (最初の写真、または目的地のストリートビュー画像)
+    Widget? thumbnail;
+    if (history.photoPaths.isNotEmpty && history.photoPaths[0] != null) {
+      final file = File(history.photoPaths[0]!);
+      if (file.existsSync()) {
+        thumbnail = Image.file(
+          file,
+          fit: BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) => const SizedBox(),
+        );
+      }
+    } else if (history.destination?.imageUtf8 != null) {
+      try {
+        final imageBytes = base64Decode(history.destination!.imageUtf8!);
+        thumbnail = Image.memory(
+          imageBytes,
+          fit: BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) => const SizedBox(),
+        );
+      } catch (_) {
+        // 画像の読み込みに失敗した場合は何も表示しない
+      }
+    }
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: InkWell(
+        onTap: () {
+          context.push('/history/${history.id}');
+        },
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              // サムネイル画像
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Container(
+                  width: 80,
+                  height: 80,
+                  color: theme.colorScheme.surfaceContainerHighest,
+                  child: thumbnail ??
+                      Icon(
+                        Icons.route,
+                        size: 40,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              // 情報
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      dateText,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.straighten,
+                          size: 16,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          distanceText,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chevron_right,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 日付をフォーマットする
+  String _formatDate(DateTime date) {
+    final year = date.year;
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    final hour = date.hour.toString().padLeft(2, '0');
+    final minute = date.minute.toString().padLeft(2, '0');
+    return '$year年$month月$day日 $hour:$minute';
+  }
+}

--- a/frontend/lib/presentation/pages/home_page.dart
+++ b/frontend/lib/presentation/pages/home_page.dart
@@ -126,7 +126,7 @@ class HistoryButton extends StatelessWidget {
         ),
       ),
       onPressed: () {
-        // TODO(kawayama): 履歴機能を実装する
+        context.push('/history');
       },
       child: Padding(
         padding: const EdgeInsets.all(20),

--- a/frontend/lib/presentation/pages/result_page.dart
+++ b/frontend/lib/presentation/pages/result_page.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:snampo/models/game_session.dart';
+import 'package:snampo/models/walk_history.dart';
 import 'package:snampo/presentation/controllers/game_session_controller.dart';
+import 'package:snampo/presentation/controllers/walk_history_controller.dart';
 
 /// ミッション完了後の結果を表示するページ
 ///
@@ -90,7 +93,20 @@ class HomeButton extends ConsumerWidget {
         foregroundColor: theme.colorScheme.onPrimary,
       ),
       onPressed: () async {
-        // ゲームセッションと写真状態をクリア (念のため)
+        // ゲームセッションを取得して履歴に保存
+        final session = await ref.read(gameSessionControllerProvider.future);
+        if (session != null && session.status == GameStatus.completed) {
+          try {
+            final history = WalkHistory.fromGameSession(session);
+            await ref
+                .read(walkHistoryControllerProvider.notifier)
+                .addHistory(history);
+          } catch (_) {
+            // 履歴の保存に失敗しても続行
+          }
+        }
+
+        // ゲームセッションと写真状態をクリア
         await ref.read(gameSessionControllerProvider.notifier).clearSession();
         ref.invalidate(hasSavedSessionProvider);
         if (context.mounted) {

--- a/frontend/lib/repositories/walk_history_repository.dart
+++ b/frontend/lib/repositories/walk_history_repository.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:snampo/models/walk_history.dart';
+
+/// 散歩履歴の永続化を担当するリポジトリ
+class WalkHistoryRepository {
+  static const String _key = 'walk_history_list';
+
+  /// すべての履歴を取得する
+  ///
+  /// 完了日時の降順 (新しい順) でソートして返す
+  Future<List<WalkHistory>> getAllHistories() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_key);
+    if (jsonString == null) {
+      return [];
+    }
+
+    try {
+      final jsonList = jsonDecode(jsonString) as List<dynamic>;
+      final histories = jsonList
+          .map((e) => WalkHistory.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      // 完了日時の降順でソート
+      return histories..sort((a, b) => b.completedAt.compareTo(a.completedAt));
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// 履歴を保存する
+  ///
+  /// [history] は保存する履歴
+  Future<void> saveHistory(WalkHistory history) async {
+    final histories = await getAllHistories();
+    // 完了日時の降順でソート
+    histories
+      ..add(history)
+      ..sort((a, b) => b.completedAt.compareTo(a.completedAt));
+
+    final prefs = await SharedPreferences.getInstance();
+    final jsonList = histories.map((e) => e.toJson()).toList();
+    await prefs.setString(_key, jsonEncode(jsonList));
+  }
+
+  /// 指定されたIDの履歴を取得する
+  ///
+  /// [id] は履歴のID
+  /// 見つからない場合は null を返す
+  Future<WalkHistory?> getHistoryById(String id) async {
+    final histories = await getAllHistories();
+    try {
+      return histories.firstWhere((h) => h.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// 指定されたIDの履歴を削除する
+  ///
+  /// [id] は削除する履歴のID
+  Future<void> deleteHistory(String id) async {
+    final histories = await getAllHistories();
+    histories.removeWhere((h) => h.id == id);
+
+    final prefs = await SharedPreferences.getInstance();
+    if (histories.isEmpty) {
+      await prefs.remove(_key);
+    } else {
+      final jsonList = histories.map((e) => e.toJson()).toList();
+      await prefs.setString(_key, jsonEncode(jsonList));
+    }
+  }
+
+  /// すべての履歴を削除する
+  Future<void> clearAllHistories() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}

--- a/frontend/lib/utils/distance_calculator.dart
+++ b/frontend/lib/utils/distance_calculator.dart
@@ -1,0 +1,72 @@
+import 'dart:developer';
+import 'dart:math' as math;
+
+import 'package:flutter_polyline_points/flutter_polyline_points.dart';
+
+/// ポリラインから距離を計算するユーティリティ
+class DistanceCalculator {
+  /// ポリライン文字列から総距離 (メートル単位) を計算する
+  ///
+  /// [polyline] はエンコードされたポリライン文字列
+  /// ポリラインが null または空の場合は 0.0 を返す
+  static double calculateDistanceFromPolyline(String? polyline) {
+    if (polyline == null || polyline.isEmpty) {
+      return 0;
+    }
+
+    try {
+      final points = PolylinePoints().decodePolyline(polyline);
+      if (points.isEmpty) {
+        return 0;
+      }
+
+      var totalDistance = 0.0;
+      for (var i = 0; i < points.length - 1; i++) {
+        totalDistance += _haversineDistance(
+          points[i].latitude,
+          points[i].longitude,
+          points[i + 1].latitude,
+          points[i + 1].longitude,
+        );
+      }
+
+      return totalDistance;
+    } catch (e) {
+      log('DistanceCalculator error: $e', name: 'DistanceCalculator');
+      return 0;
+    }
+  }
+
+  /// Haversine公式を使用して2点間の距離を計算する (メートル単位)
+  ///
+  /// [lat1] は地点1の緯度
+  /// [lon1] は地点1の経度
+  /// [lat2] は地点2の緯度
+  /// [lon2] は地点2の経度
+  static double _haversineDistance(
+    double lat1,
+    double lon1,
+    double lat2,
+    double lon2,
+  ) {
+    const double earthRadius = 6371000; // 地球の半径 (メートル)
+
+    final dLat = _toRadians(lat2 - lat1);
+    final dLon = _toRadians(lon2 - lon1);
+
+    final a = math.sin(dLat / 2) * math.sin(dLat / 2) +
+        math.cos(_toRadians(lat1)) *
+            math.cos(_toRadians(lat2)) *
+            math.sin(dLon / 2) *
+            math.sin(dLon / 2);
+
+    final c = 2 * math.asin(math.sqrt(a));
+
+    return earthRadius * c;
+  }
+
+  /// 度をラジアンに変換する
+  static double _toRadians(double degrees) {
+    return degrees * (math.pi / 180.0);
+  }
+}


### PR DESCRIPTION
## 概要
散歩履歴機能を追加しました。ミッション完了後に履歴が自動保存され、過去の散歩を振り返ることができます。

Closes #75

## 変更内容
- 履歴一覧ページ (`HistoryListPage`) の追加
  - サムネイル画像、日付、距離を表示
  - プルリフレッシュで再読み込み
- 履歴詳細ページ (`HistoryDetailPage`) の追加
  - Google Mapsでルートとマーカーを表示
  - 撮影した写真やストリートビュー画像のギャラリー表示
- `WalkHistory` モデルの追加
  - `GameSession` からの変換をサポート
  - JSON シリアライゼーション対応
- `WalkHistoryController` / `WalkHistoryRepository` の追加
  - Riverpodによる状態管理
  - SharedPreferencesを使った永続化
- `DistanceCalculator` ユーティリティの追加
  - ポリラインからHaversine公式で距離を計算
- ホーム画面の履歴ボタンから履歴一覧へ遷移できるように変更
- 結果画面でホームに戻る際に履歴を自動保存

## テスト
- 散歩ミッションを完了し、結果画面からホームに戻る
- ホーム画面の履歴ボタンをタップして履歴一覧を確認
- 履歴をタップして詳細ページで地図と写真を確認

## 備考
- 履歴データは端末ローカルに保存されます (SharedPreferences)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ウォーキング履歴の保存・管理機能を追加しました
  * 完了したウォークが自動的に履歴に保存されるようになりました
  * 履歴一覧ページで過去のウォークを確認できます
  * 履歴詳細ページでルート地図、走行距離、撮影写真を表示します
  * ホームボタンから履歴ページへ直接アクセスできるようになりました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->