### PR TITLE
fix: Base64画像データのログ出力を削除

### DIFF
--- a/frontend/lib/features/mission/presentation/page/mission_page.dart
+++ b/frontend/lib/features/mission/presentation/page/mission_page.dart
@@ -359,11 +359,7 @@ class AnswerImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    log('answer image utf8 is');
-    log(imageBase64);
     final imageUint8 = base64Decode(imageBase64);
-    log('imageUint8 is');
-    log(imageUint8.toString());
     return SizedBox(
       width: 150,
       height: 150,


### PR DESCRIPTION
Flutterのログ画面が占領されて鬱陶しい上にセキュリティリスクになるので、Base64のログ出力を削除した

- Base64エンコードされた画像データ全体のログ出力を削除
- デコード後のバイト配列のログ出力を削除

#160