### PR TITLE
chore: iOSビルドに難読化設定を追加

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -55,10 +55,15 @@ workflows:
         script: |
           flutter analyze --no-fatal-infos
       - name: Flutter build ipa
+        # 難読化をしている
+        # ref: https://docs.flutter.dev/deployment/obfuscate
         # build-numberでビルドバージョンの衝突を防ぐ
         # ref: https://docs.codemagic.io/knowledge-codemagic/build-versioning/#build-versioning-in-codemagic
         script: |
           flutter build ipa --release \
+            --obfuscate \
+            --split-debug-info=build/ios/symbols \
+            --no-tree-shake-icons \
             --export-options-plist /Users/builder/export_options.plist \
             --dart-define=GOOGLE_MAP_API_KEY=$GOOGLE_MAP_API_KEY \
             --dart-define=FLAVOR=$FLAVOR \
@@ -66,6 +71,7 @@ workflows:
             --build-number=$PROJECT_BUILD_NUMBER
     artifacts:
       - build/ios/ipa/*.ipa
+      - build/ios/symbols/
       - /tmp/xcodebuild_logs/*.log
       - flutter_drive.log
     publishing:


### PR DESCRIPTION
## 概要
iOSビルドに難読化設定を追加しました。
Flutter公式ドキュメント (https://docs.flutter.dev/deployment/obfuscate) に基づいて設定しています。

関連Issue: #46

## 変更内容
- `codemagic.yaml` のiOSビルド設定に以下を追加:
  - `--obfuscate` フラグ: コードの難読化を有効化
  - `--split-debug-info=build/ios/symbols`: デバッグ情報を別ファイルに分離
  - `--no-tree-shake-icons`: アイコンのツリーシェイキングを無効化
  - `build/ios/symbols/` をアーティファクトに追加

https://github.com/nakamaware/snampo/blob/a98aef7ae25f2b365b6e391fae2c97d137218647/codemagic.yaml#L62-L71

## テスト
- [ ] Codemagicでのビルドが成功することを確認
- [ ] 難読化されたIPAファイルが正常に生成されることを確認

→ ローカルでは確認済み。CD環境はぶっつけ本番で

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOSビルド設定を改善し、アプリの難読化とデバッグシンボル管理を強化しました。セキュリティと開発効率が向上します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->