### PR TITLE
ci: CIからbuild-apkジョブを削除

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -38,33 +38,6 @@ jobs:
       - name: Analyze
         run: flutter analyze --no-fatal-infos
 
-  build-apk:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Frontend Setup
-        uses: ./.github/actions/setup-frontend
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            frontend/android/.gradle
-            frontend/android/build
-          key: >-
-            ${{ runner.os }}-gradle-${{ hashFiles(
-              'frontend/android/**/*.gradle*',
-              'frontend/android/gradle/wrapper/gradle-wrapper.properties'
-            ) }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: Build APK (debug)
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.daemon=true -Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
-        run: flutter build apk --debug --target-platform android-arm64 --no-tree-shake-icons
-
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 概要
- CI (ci-frontend.yml) からdebug APKビルドジョブ (`build-apk`) を削除
- CD (cd-frontend.yml) のリリースビルドは維持

Close #176

## テスト
- CIワークフローの構文エラーがないことを確認

## 備考
- https://github.com/nakamaware/snampo/discussions/140#discussioncomment-15540665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チェア (Chores)**
  * フロントエンド CI ワークフロー内の APK ビルドプロセスを削除しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->