### PR TITLE
feat: ライセンスページの追加

### DIFF
--- a/frontend/lib/features/home/presentation/page/home_page.dart
+++ b/frontend/lib/features/home/presentation/page/home_page.dart
@@ -9,20 +9,25 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            SizedBox(
-              width: 300,
-              child: Image.asset('images/snampo.png', fit: BoxFit.contain),
+      body: Stack(
+        children: [
+          Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                SizedBox(
+                  width: 300,
+                  child: Image.asset('images/snampo.png', fit: BoxFit.contain),
+                ),
+                const SizedBox(height: 20),
+                const StartButton(),
+                const SizedBox(height: 10), // 2つの間を空ける
+                const HistoryButton(),
+              ],
             ),
-            const SizedBox(height: 20),
-            const StartButton(),
-            const SizedBox(height: 10), // 2つの間を空ける
-            const HistoryButton(),
-          ],
-        ),
+          ),
+          const Positioned(bottom: 20, right: 20, child: InfoIconButton()),
+        ],
       ),
     );
   }
@@ -84,6 +89,25 @@ class HistoryButton extends StatelessWidget {
         padding: const EdgeInsets.all(20),
         child: Text('履歴', style: style),
       ),
+    );
+  }
+}
+
+/// ライセンスのアイコンウィジェット
+class InfoIconButton extends StatelessWidget {
+  /// InfoIconButtonのコンストラクタ
+  const InfoIconButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return IconButton(
+      icon: const Icon(Icons.info),
+      color: theme.colorScheme.primary,
+      onPressed: () {
+        showLicensePage(context: context);
+      },
     );
   }
 }


### PR DESCRIPTION
#70

ホームにライセンスページを表示するアイコンを追加

https://github.com/user-attachments/assets/79537382-3e03-4764-9f95-b30a8bc4f213



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ホームページの右下に情報アイコンを追加しました。このアイコンをタップするとライセンスページが表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->