### PR TITLE
chore: アプリ表示名をスナんぽに統一 (Android / iOS / アプリ内)

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <application
-        android:label="snampo"
+        android:label="スナんぽ"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true">

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Snampo</string>
+	<string>スナんぽ</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>snampo</string>
+	<string>スナんぽ</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -23,7 +23,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
-      title: 'SNAMPO',
+      title: 'スナんぽ',
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: ColorScheme.fromSeed(


### PR DESCRIPTION
## 概要
Android・iPhone のランチャー名と、Flutter の `MaterialApp.title` を「スナんぽ」に揃えました。

## 変更内容
- **Android**: `AndroidManifest.xml` の `android:label`
- **iOS**: `Info.plist` の `CFBundleDisplayName` / `CFBundleName`
- **アプリ内**: `main.dart` の `MaterialApp.router` の `title` (タスクスイッチャー等で参照)

|android (アプリ一覧)|android (履歴)|ios (アプリ一覧)|ios (履歴)|
|---|---|---|---|
|<img src="https://github.com/user-attachments/assets/dcbdde87-41c7-4149-9cab-21e98c7b6342" width=200>|<img src="https://github.com/user-attachments/assets/2f6c52ea-9764-4465-a2a3-00774307c3d6" width=200>|<img src="https://github.com/user-attachments/assets/e071d12e-58cd-49ad-bdfb-dd5832e001ab" width=200>|<img src="https://github.com/user-attachments/assets/1803005c-6b0c-40b8-adda-485308304114" width=200>|

## 補足
Web の `manifest.json` / `index.html` は今回のスコープ外です。必要なら別 PR で対応できます。