### PR TITLE
feat: prod環境にRate Limitを追加

### DIFF
--- a/terraform/env/prod/cloud_quotas.tf
+++ b/terraform/env/prod/cloud_quotas.tf
@@ -1,0 +1,77 @@
+# Cloud Quotas コンソールとの対応
+# - サービスID            → service
+# - 上限名                → quota_id
+# - 名前                  → service + quota_id から自動生成 (Terraform からは指定しない)
+# - 項目 (ロケーション等) → dimensions
+# - 値                    → quota_config.preferred_value
+# - 対象プロジェクト      → parent = "projects/<project-id>"
+
+resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_directions_api" {
+  depends_on = [module.snampo_prod]
+
+  service  = "directions-backend.googleapis.com"
+  quota_id = "BillableDefaultPerDayPerProject"
+  parent   = "projects/${local.project_id}"
+
+  quota_config {
+    preferred_value = 1000
+  }
+
+  ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
+}
+
+resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_new_places_api" {
+  depends_on = [module.snampo_prod]
+
+  service  = "places.googleapis.com"
+  quota_id = "SearchNearbyRequestPerDayPerProject"
+  parent   = "projects/${local.project_id}"
+
+  quota_config {
+    preferred_value = 1000
+  }
+
+  ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
+}
+
+resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_roads_api" {
+  depends_on = [module.snampo_prod]
+
+  service  = "roads.googleapis.com"
+  quota_id = "BillableDefaultPerDayPerProject"
+  parent   = "projects/${local.project_id}"
+
+  quota_config {
+    preferred_value = 1000
+  }
+
+  ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
+}
+
+resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_api_from_be" {
+  depends_on = [module.snampo_prod]
+
+  service  = "street-view-image-backend.googleapis.com"
+  quota_id = "StreetViewMetadataPerDayPerProject"
+  parent   = "projects/${local.project_id}"
+
+  quota_config {
+    preferred_value = 1000
+  }
+
+  ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
+}
+
+resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_api_from_app" {
+  depends_on = [module.snampo_prod]
+
+  service  = "street-view-image-backend.googleapis.com"
+  quota_id = "BillableUnsignedbucketPerDayPerProject"
+  parent   = "projects/${local.project_id}"
+
+  quota_config {
+    preferred_value = 1000
+  }
+
+  ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
+}


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、 `#<IssueNumber>` でリンクできる -->
- #152 
- dev環境に追加した際のPR
  - #205 

## テスト
<!-- テスト方法や結果、画像などがあると良い -->
- GCPのGoogle MapのAPIのページから以下に上限が設定されていることを確認する
  - Directions API
    - BillableDefaultPerDayPerProject
  - Places API (New)
    - SearchNearbyRequestPerDayPerProject
  - Roads API
    - BillableDefaultPerDayPerProject
  - Street View Static API
    - StreetViewMetadataPerDayPerProject
    - BillableUnsignedbucketPerDayPerProject

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->

### API上限数の根拠
1ヶ月の無料枠が各APIで10,000回なので1日あたり1000回にする
- https://mapsplatform.google.com/pricing/?hl=ja#pay-as-you-go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Production環境のGoogle CloudAPIクォータ設定を更新しました。複数のサービスAPIのクォータ上限値を設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->