### PR TITLE
fix: Nearby Search を Pro SKU に揃え Landmark から rating を削除

### DIFF
--- a/backend/app/domain/value_objects/landmark.py
+++ b/backend/app/domain/value_objects/landmark.py
@@ -18,4 +18,3 @@ class Landmark(BaseModel):
     coordinate: Coordinate = Field(description="座標")
     primary_type: str | None = Field(default=None, description="主要タイプ")
     types: list[str] | None = Field(default=None, description="すべてのタイプ")
-    rating: float | None = Field(default=None, ge=0.0, le=5.0, description="評価 (0.0-5.0)")

--- a/backend/app/infrastructure/gateways/google_maps_gateway_impl.py
+++ b/backend/app/infrastructure/gateways/google_maps_gateway_impl.py
@@ -377,7 +377,6 @@ class GoogleMapsGatewayImpl(GoogleMapsGateway):
 
             primary_type = place.get("primaryType")
             types = place.get("types")
-            rating = place.get("rating")
 
             landmark = Landmark(
                 place_id=place_id,
@@ -385,7 +384,6 @@ class GoogleMapsGatewayImpl(GoogleMapsGateway):
                 coordinate=landmark_coordinate,
                 primary_type=primary_type,
                 types=types if isinstance(types, list) else None,
-                rating=float(rating) if rating is not None else None,
             )
             landmarks.append(landmark)
 
@@ -442,8 +440,7 @@ class GoogleMapsGatewayImpl(GoogleMapsGateway):
             "Content-Type": "application/json",
             "X-Goog-Api-Key": GOOGLE_API_KEY,
             "X-Goog-FieldMask": (
-                "places.id,places.displayName,places.location,"
-                "places.primaryType,places.types,places.rating,places.userRatingCount"
+                "places.id,places.displayName,places.location,places.primaryType,places.types"
             ),
         }
 

--- a/backend/tests/app/domain/value_objects/test_landmark.py
+++ b/backend/tests/app/domain/value_objects/test_landmark.py
@@ -21,7 +21,6 @@ def test_必須フィールドのみで作成できること() -> None:
     assert landmark.coordinate == coordinate
     assert landmark.primary_type is None
     assert landmark.types is None
-    assert landmark.rating is None
 
 
 def test_すべてのフィールドを指定して作成できること() -> None:
@@ -33,7 +32,6 @@ def test_すべてのフィールドを指定して作成できること() -> No
         coordinate=coordinate,
         primary_type="train_station",
         types=["train_station", "transit_station", "point_of_interest"],
-        rating=4.5,
     )
 
     assert landmark.place_id == "ChIJXSModoWLGGARILWiCfeu2M0"
@@ -41,7 +39,6 @@ def test_すべてのフィールドを指定して作成できること() -> No
     assert landmark.coordinate == coordinate
     assert landmark.primary_type == "train_station"
     assert landmark.types == ["train_station", "transit_station", "point_of_interest"]
-    assert landmark.rating == 4.5
 
 
 def test_place_idが空文字でValidationErrorが発生すること() -> None:
@@ -68,53 +65,6 @@ def test_display_nameが空文字でValidationErrorが発生すること() -> No
         )
 
 
-def test_ratingが0未満でValidationErrorが発生すること() -> None:
-    """ratingが0未満の場合、ValidationErrorが発生することを確認"""
-    coordinate = Coordinate(latitude=35.6812, longitude=139.7671)
-
-    with pytest.raises(ValidationError):
-        Landmark(
-            place_id="ChIJXSModoWLGGARILWiCfeu2M0",
-            display_name="東京駅",
-            coordinate=coordinate,
-            rating=-0.1,
-        )
-
-
-def test_ratingが5超過でValidationErrorが発生すること() -> None:
-    """ratingが5.0を超える場合、ValidationErrorが発生することを確認"""
-    coordinate = Coordinate(latitude=35.6812, longitude=139.7671)
-
-    with pytest.raises(ValidationError):
-        Landmark(
-            place_id="ChIJXSModoWLGGARILWiCfeu2M0",
-            display_name="東京駅",
-            coordinate=coordinate,
-            rating=5.1,
-        )
-
-
-def test_ratingの境界値で作成できること() -> None:
-    """ratingの境界値 (0.0と5.0) でLandmarkを作成できることを確認"""
-    coordinate = Coordinate(latitude=35.6812, longitude=139.7671)
-
-    landmark_min = Landmark(
-        place_id="ChIJXSModoWLGGARILWiCfeu2M0",
-        display_name="東京駅",
-        coordinate=coordinate,
-        rating=0.0,
-    )
-    landmark_max = Landmark(
-        place_id="ChIJXSModoWLGGARILWiCfeu2M0",
-        display_name="東京駅",
-        coordinate=coordinate,
-        rating=5.0,
-    )
-
-    assert landmark_min.rating == 0.0
-    assert landmark_max.rating == 5.0
-
-
 def test_不変性が保証されていること() -> None:
     """frozen=Trueにより不変性が保証されていることを確認"""
     coordinate = Coordinate(latitude=35.6812, longitude=139.7671)
@@ -138,7 +88,6 @@ def test_同じ値のLandmarkが等しいこと() -> None:
         coordinate=coordinate,
         primary_type="train_station",
         types=["train_station"],
-        rating=4.5,
     )
     landmark2 = Landmark(
         place_id="ChIJXSModoWLGGARILWiCfeu2M0",
@@ -146,7 +95,6 @@ def test_同じ値のLandmarkが等しいこと() -> None:
         coordinate=coordinate,
         primary_type="train_station",
         types=["train_station"],
-        rating=4.5,
     )
 
     assert landmark1 == landmark2

--- a/backend/tests/app/infrastructure/gateways/test_google_maps_gateway.py
+++ b/backend/tests/app/infrastructure/gateways/test_google_maps_gateway.py
@@ -10,6 +10,62 @@ from app.domain.exceptions import ExternalServiceError
 from app.domain.value_objects import Coordinate, ImageSize, Landmark
 from app.infrastructure.gateways.google_maps_gateway_impl import GoogleMapsGatewayImpl
 
+# Nearby Search (新版) の FieldMask で Pro 以外の SKU を誘発するトークン
+# https://developers.google.com/maps/documentation/places/web-service/nearby-search
+_NEARBY_SEARCH_ENTERPRISE_SKU_FIELD_MASK_TOKENS: frozenset[str] = frozenset(
+    {
+        "places.currentOpeningHours",
+        "places.currentSecondaryOpeningHours",
+        "places.internationalPhoneNumber",
+        "places.nationalPhoneNumber",
+        "places.priceLevel",
+        "places.priceRange",
+        "places.rating",
+        "places.regularOpeningHours",
+        "places.regularSecondaryOpeningHours",
+        "places.userRatingCount",
+        "places.websiteUri",
+    }
+)
+_NEARBY_SEARCH_ENTERPRISE_ATMOSPHERE_SKU_FIELD_MASK_TOKENS: frozenset[str] = frozenset(
+    {
+        "places.allowsDogs",
+        "places.curbsidePickup",
+        "places.delivery",
+        "places.dineIn",
+        "places.editorialSummary",
+        "places.evChargeAmenitySummary",
+        "places.evChargeOptions",
+        "places.fuelOptions",
+        "places.generativeSummary",
+        "places.goodForChildren",
+        "places.goodForGroups",
+        "places.goodForWatchingSports",
+        "places.liveMusic",
+        "places.menuForChildren",
+        "places.neighborhoodSummary",
+        "places.parkingOptions",
+        "places.paymentOptions",
+        "places.outdoorSeating",
+        "places.reservable",
+        "places.restroom",
+        "places.reviews",
+        "places.reviewSummary",
+        "routingSummaries",
+        "places.servesBeer",
+        "places.servesBreakfast",
+        "places.servesBrunch",
+        "places.servesCocktails",
+        "places.servesCoffee",
+        "places.servesDessert",
+        "places.servesDinner",
+        "places.servesLunch",
+        "places.servesVegetarianFood",
+        "places.servesWine",
+        "places.takeout",
+    }
+)
+
 
 class TestGetDirections:
     """GetDirectionsのテスト"""
@@ -781,6 +837,36 @@ class TestSearchLandmarksNearby:
             circle = request_body.get("locationRestriction", {}).get("circle", {})
             assert circle.get("radius") == PLACES_API_MAX_SEARCH_RADIUS_M
 
+    def test_searchNearbyのFieldMaskにEnterpriseSKUのフィールドが含まれないこと(self) -> None:
+        """Pro SKU のみにするため、Enterprise / Enterprise+Atmosphere のフィールドを含まない。"""
+        coordinate = Coordinate(latitude=35.6812, longitude=139.7671)
+        radius = 1000
+
+        mock_response_data = {"places": []}
+
+        with patch(
+            "app.infrastructure.gateways.google_maps_gateway_impl.requests.post"
+        ) as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_response_data
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            mock_post.return_value = mock_response
+
+            gateway = GoogleMapsGatewayImpl()
+            gateway.search_landmarks_nearby(coordinate, radius)
+
+            call_args = mock_post.call_args
+            assert call_args is not None
+            headers = call_args.kwargs.get("headers", {})
+            field_mask = headers.get("X-Goog-FieldMask", "")
+            masked_tokens = {t.strip() for t in field_mask.split(",") if t.strip()}
+            non_pro_tokens = (
+                _NEARBY_SEARCH_ENTERPRISE_SKU_FIELD_MASK_TOKENS
+                | _NEARBY_SEARCH_ENTERPRISE_ATMOSPHERE_SKU_FIELD_MASK_TOKENS
+            )
+            assert masked_tokens.isdisjoint(non_pro_tokens)
+
     def test_正常なレスポンスからLandmarkリストが返されること(self) -> None:
         """正常なレスポンスからLandmarkリストが返されることを確認"""
         coordinate = Coordinate(latitude=35.6812, longitude=139.7671)
@@ -799,7 +885,6 @@ class TestSearchLandmarksNearby:
                         "point_of_interest",
                         "establishment",
                     ],
-                    "rating": 4.5,
                 },
                 {
                     "id": "ChIJN1t_tDeuEmsRUsoyG83frY5",
@@ -807,7 +892,6 @@ class TestSearchLandmarksNearby:
                     "location": {"latitude": 35.6850, "longitude": 139.7528},
                     "primaryType": "tourist_attraction",
                     "types": ["tourist_attraction", "point_of_interest", "establishment"],
-                    "rating": 4.7,
                 },
             ]
         }
@@ -838,7 +922,6 @@ class TestSearchLandmarksNearby:
                 "point_of_interest",
                 "establishment",
             ]
-            assert landmarks[0].rating == 4.5
 
     def test_空のレスポンスから空のリストが返されること(self) -> None:
         """空のレスポンスから空のリストが返されることを確認"""
@@ -913,7 +996,6 @@ class TestSearchLandmarksNearby:
                     "displayName": {"text": "東京駅"},
                     "location": {"latitude": 35.6812, "longitude": 139.7671},
                     "primaryType": "train_station",
-                    "rating": 4.5,
                 },
             ]
         }
@@ -952,7 +1034,6 @@ class TestSearchLandmarksNearby:
                     "displayName": {"text": "東京駅"},
                     "location": {"latitude": 35.6812, "longitude": 139.7671},
                     "primaryType": "train_station",
-                    "rating": 4.5,
                 },
             ]
         }
@@ -989,7 +1070,6 @@ class TestSearchLandmarksNearby:
                     "displayName": {"text": "東京駅"},
                     "location": {"latitude": 35.6812, "longitude": 139.7671},
                     "primaryType": "train_station",
-                    "rating": 4.5,
                 },
             ]
         }


### PR DESCRIPTION
## 概要

Places API (New) の Nearby Search (`searchNearby`) で [Nearby Search Enterprise SKU](https://developers.google.com/maps/documentation/places/web-service/nearby-search?hl=ja-JP) を誘発していた `places.rating` / `places.userRatingCount` を `X-Goog-FieldMask` から外し、課金を Pro SKU に揃えます。あわせてドメインの `Landmark` から `rating` を削除し、FieldMask に Enterprise / Enterprise+Atmosphere SKU のフィールドが混ざらない回帰テストを追加しました。

関連: #223

## テスト

- `uv run pytest`（backend 全件）: 149 passed

## 備考

- `frontend/pubspec.lock` のローカル変更は本 PR には含めていません（Issue 223 と無関係な差分のため）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能変更**
  * ランドマークの評価フィールドを削除しました。

* **パフォーマンス改善**
  * Google Maps APIリクエストを最適化し、不要なフィールド取得を停止しました。

* **テスト**
  * 関連テストを更新し、新しいテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->