### PR TITLE
feat: ルート生成で中間地点と目的地の重複を排除する

### DIFF
--- a/backend/app/application/usecases/generate_route_usecase.py
+++ b/backend/app/application/usecases/generate_route_usecase.py
@@ -18,6 +18,7 @@ from app.config import (
     DIRECTIONS_API_MAX_WAYPOINTS,
     LANDMARK_SEARCH_MAX_CALLS,
     LANDMARK_SEARCH_TARGET_COUNT,
+    MIDPOINT_DEDUP_MIN_DISTANCE_TO_DESTINATION_M,
     MIDPOINT_MIN_SEARCH_RADIUS_M,
 )
 from app.domain.exceptions import (
@@ -29,6 +30,7 @@ from app.domain.services import coordinate_service
 from app.domain.services.mission_point_calculation_service import calculate_mission_point_count
 from app.domain.value_objects import (
     Coordinate,
+    Landmark,
     StreetViewImage,
 )
 
@@ -94,6 +96,7 @@ class GenerateRouteUseCase:
 
         try:
             destination_image: StreetViewImage | None = None
+            used_place_ids: set[str] = set()
 
             # 1. 目的地の決定
             if destination_coordinate is not None:
@@ -124,9 +127,10 @@ class GenerateRouteUseCase:
                         service_name="Places API",
                     )
 
-                _, destination_image = self.landmark_selector.select(
+                destination_landmark, destination_image = self.landmark_selector.select(
                     destination_landmarks, shuffle=True
                 )
+                used_place_ids.add(destination_landmark.place_id)
                 destination_coordinate = destination_image.metadata_coordinate
                 logger.info("Successfully fetched Street View image for random destination")
 
@@ -189,9 +193,22 @@ class GenerateRouteUseCase:
                 )
 
                 if landmarks:
-                    # 画像付きランドマークを選択
+                    filtered_landmarks = self._filter_midpoint_landmark_candidates(
+                        landmarks, used_place_ids, destination_coordinate
+                    )
+                    if not filtered_landmarks:
+                        logger.warning(
+                            (
+                                "All landmark candidates for mission point %s/%s were "
+                                "filtered as duplicates of the destination or prior midpoints"
+                            ),
+                            i,
+                            midpoint_target_count,
+                        )
+                        continue
                     try:
-                        _, image = self.landmark_selector.select(landmarks)
+                        landmark, image = self.landmark_selector.select(filtered_landmarks)
+                        used_place_ids.add(landmark.place_id)
                         midpoint_results.append((image.metadata_coordinate, image))
                         logger.info(f"Mission point {i} found at {image.metadata_coordinate}")
                     except ExternalServiceValidationError:
@@ -237,3 +254,22 @@ class GenerateRouteUseCase:
                     "Street View画像が取得可能なルートが見つかりませんでした"
                 ),
             ) from e
+
+    @staticmethod
+    def _filter_midpoint_landmark_candidates(
+        landmarks: list[Landmark],
+        used_place_ids: set[str],
+        destination_coordinate: Coordinate,
+    ) -> list[Landmark]:
+        """中間地点用に、目的地・既採用地点と重複するランドマークを除いた候補を返す"""
+        out: list[Landmark] = []
+        for lm in landmarks:
+            if lm.place_id in used_place_ids:
+                continue
+            if (
+                coordinate_service.calculate_distance(lm.coordinate, destination_coordinate)
+                < MIDPOINT_DEDUP_MIN_DISTANCE_TO_DESTINATION_M
+            ):
+                continue
+            out.append(lm)
+        return out

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,7 @@ LANDMARK_SEARCH_TIME_BUDGET_MS = 3000  # タイムアウト予算 (ミリ秒)
 MIN_SEARCH_RADIUS_M = 50  # Google Maps Nearby Search APIの最小検索半径 (メートル)
 PLACES_API_MAX_SEARCH_RADIUS_M = 50000  # Places API searchNearby の最大検索半径 (メートル)
 MIDPOINT_MIN_SEARCH_RADIUS_M = 300  # 中間地点検索の最小半径 (メートル)
+MIDPOINT_DEDUP_MIN_DISTANCE_TO_DESTINATION_M = 10  # 中間地点と最終目的地の重複判定 (メートル)
 
 # Directions API制約
 DIRECTIONS_API_MAX_WAYPOINTS = 25  # origin/destination を除く waypoint 最大数

--- a/backend/tests/app/application/usecases/test_generate_route_usecase.py
+++ b/backend/tests/app/application/usecases/test_generate_route_usecase.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from app.application.usecases.generate_route_usecase import GenerateRouteUseCase
 from app.config import DIRECTIONS_API_MAX_WAYPOINTS
-from app.domain.value_objects import Coordinate, StreetViewImage
+from app.domain.services.coordinate_service import calculate_distance as real_calculate_distance
+from app.domain.value_objects import Coordinate, Landmark, StreetViewImage
 
 
 def test_execute_目的地指定モードでは距離算出後にミッション地点数を計算すること() -> None:
@@ -251,3 +252,244 @@ def test_execute_実ルート上の候補地点生成にルート座標列を使
         route_coordinates=route_coordinates,
         num_segments=1,
     )
+
+
+def test_filter_midpoint_landmark_candidates_place_idと至近距離で除外すること() -> None:
+    """_filter_midpoint_landmark_candidates が used と目的地至近を除くことを確認"""
+    destination = Coordinate(latitude=35.6895, longitude=139.6917)
+    far = Coordinate(latitude=35.6800, longitude=139.7600)
+    lm_used = Landmark(
+        place_id="ChIJ_used",
+        display_name="Used",
+        coordinate=far,
+    )
+    lm_near_dest = Landmark(
+        place_id="ChIJ_near",
+        display_name="NearDest",
+        coordinate=destination,
+    )
+    lm_ok = Landmark(
+        place_id="ChIJ_ok",
+        display_name="Ok",
+        coordinate=far,
+    )
+    used: set[str] = {"ChIJ_used"}
+    filtered = GenerateRouteUseCase._filter_midpoint_landmark_candidates(
+        [lm_used, lm_near_dest, lm_ok],
+        used,
+        destination,
+    )
+    assert len(filtered) == 1
+    assert filtered[0].place_id == "ChIJ_ok"
+
+
+def test_execute_同一place_idの2つ目のセグメントは中間地点を付与しないこと() -> None:
+    """2セグメント目で候補がすべて既採用と同一 place_id なら waypoint が1件のまま"""
+    current_coordinate = Coordinate(latitude=35.6812, longitude=139.7671)
+    destination_coordinate = Coordinate(latitude=35.6895, longitude=139.6917)
+    destination_image = StreetViewImage(
+        metadata_coordinate=destination_coordinate,
+        original_coordinate=destination_coordinate,
+        image_data=b"destination-image",
+    )
+    route_coordinates = [
+        current_coordinate,
+        Coordinate(latitude=35.6850, longitude=139.7300),
+        destination_coordinate,
+    ]
+    lm1 = Landmark(
+        place_id="ChIJ_first",
+        display_name="First",
+        coordinate=Coordinate(latitude=35.6840, longitude=139.7200),
+    )
+    lm2 = Landmark(
+        place_id="ChIJ_second",
+        display_name="Second",
+        coordinate=Coordinate(latitude=35.6845, longitude=139.7210),
+    )
+    mid_image = StreetViewImage(
+        metadata_coordinate=lm1.coordinate,
+        original_coordinate=lm1.coordinate,
+        image_data=b"mid-image",
+    )
+
+    google_maps_gateway = MagicMock()
+    google_maps_gateway.get_directions.side_effect = [
+        (route_coordinates, "initial-overview-polyline"),
+        ([], "overview-polyline"),
+    ]
+    google_maps_gateway.search_landmarks_nearby.side_effect = [
+        [lm1, lm2],
+        [lm1],
+    ]
+    landmark_search_service = MagicMock()
+    landmark_selector = MagicMock()
+    landmark_selector.select.return_value = (lm1, mid_image)
+    street_view_image_fetch_service = MagicMock()
+    street_view_image_fetch_service.get_image.return_value = destination_image
+
+    usecase = GenerateRouteUseCase(
+        google_maps_gateway=google_maps_gateway,
+        landmark_search_service=landmark_search_service,
+        landmark_selector=landmark_selector,
+        street_view_image_fetch_service=street_view_image_fetch_service,
+    )
+
+    with (
+        patch(
+            "app.application.usecases.generate_route_usecase.coordinate_service.calculate_distance",
+            return_value=1200,
+        ),
+        patch(
+            "app.application.usecases.generate_route_usecase.coordinate_service.divide_route_into_segments",
+            return_value=[
+                Coordinate(latitude=35.6830, longitude=139.7150),
+                Coordinate(latitude=35.6835, longitude=139.7160),
+            ],
+        ),
+        patch(
+            "app.application.usecases.generate_route_usecase.calculate_mission_point_count",
+            return_value=2,
+        ),
+    ):
+        result = usecase.execute(
+            current_coordinate=current_coordinate,
+            destination_coordinate=destination_coordinate,
+        )
+
+    assert len(result.midpoints) == 1
+    assert result.midpoints[0] == mid_image.metadata_coordinate
+    assert landmark_selector.select.call_count == 1
+    assert google_maps_gateway.get_directions.call_args_list[1].kwargs["waypoints"] == [
+        mid_image.metadata_coordinate
+    ]
+
+
+def test_execute_候補が目的地と至近のみなら中間地点を付与しないこと() -> None:
+    """フィルタ後に候補が空なら get_directions の waypoints は空"""
+    current_coordinate = Coordinate(latitude=35.6812, longitude=139.7671)
+    destination_coordinate = Coordinate(latitude=35.6895, longitude=139.6917)
+    destination_image = StreetViewImage(
+        metadata_coordinate=destination_coordinate,
+        original_coordinate=destination_coordinate,
+        image_data=b"destination-image",
+    )
+    route_coordinates = [
+        current_coordinate,
+        Coordinate(latitude=35.6850, longitude=139.7300),
+        destination_coordinate,
+    ]
+    lm_at_dest = Landmark(
+        place_id="ChIJ_at_dest",
+        display_name="AtDest",
+        coordinate=destination_coordinate,
+    )
+
+    google_maps_gateway = MagicMock()
+    google_maps_gateway.get_directions.side_effect = [
+        (route_coordinates, "initial-overview-polyline"),
+        ([], "overview-polyline"),
+    ]
+    google_maps_gateway.search_landmarks_nearby.return_value = [lm_at_dest]
+    landmark_search_service = MagicMock()
+    landmark_selector = MagicMock()
+    street_view_image_fetch_service = MagicMock()
+    street_view_image_fetch_service.get_image.return_value = destination_image
+
+    usecase = GenerateRouteUseCase(
+        google_maps_gateway=google_maps_gateway,
+        landmark_search_service=landmark_search_service,
+        landmark_selector=landmark_selector,
+        street_view_image_fetch_service=street_view_image_fetch_service,
+    )
+
+    def distance_side_effect(a: Coordinate, b: Coordinate) -> float:
+        if a == current_coordinate and b == destination_coordinate:
+            return 1200.0
+        return real_calculate_distance(a, b)
+
+    with (
+        patch(
+            "app.application.usecases.generate_route_usecase.coordinate_service.calculate_distance",
+            side_effect=distance_side_effect,
+        ),
+        patch(
+            "app.application.usecases.generate_route_usecase.coordinate_service.divide_route_into_segments",
+            return_value=[Coordinate(latitude=35.6850, longitude=139.7300)],
+        ),
+        patch(
+            "app.application.usecases.generate_route_usecase.calculate_mission_point_count",
+            return_value=1,
+        ),
+    ):
+        result = usecase.execute(
+            current_coordinate=current_coordinate,
+            destination_coordinate=destination_coordinate,
+        )
+
+    assert result.midpoints == []
+    landmark_selector.select.assert_not_called()
+    assert google_maps_gateway.get_directions.call_args_list[1].kwargs["waypoints"] == []
+
+
+def test_execute_ランダムモードで目的地と同一place_idの中間候補はスキップされること() -> None:
+    """ランダム目的地の place_id を used に入れ、同一 ID の中間候補は採用しない"""
+    current_coordinate = Coordinate(latitude=35.6812, longitude=139.7671)
+    dest_coord = Coordinate(latitude=35.6895, longitude=139.6917)
+    dest_landmark = Landmark(
+        place_id="ChIJ_dest",
+        display_name="Dest",
+        coordinate=dest_coord,
+    )
+    dest_image = StreetViewImage(
+        metadata_coordinate=dest_coord,
+        original_coordinate=dest_coord,
+        image_data=b"destination-image",
+    )
+    route_coordinates = [
+        current_coordinate,
+        Coordinate(latitude=35.6850, longitude=139.7300),
+        dest_coord,
+    ]
+
+    google_maps_gateway = MagicMock()
+    google_maps_gateway.get_directions.side_effect = [
+        (route_coordinates, "initial-overview-polyline"),
+        ([], "overview-polyline"),
+    ]
+    google_maps_gateway.search_landmarks_nearby.return_value = [dest_landmark]
+    landmark_search_service = MagicMock()
+    landmark_search_service.search_landmarks.return_value = [dest_landmark]
+    landmark_selector = MagicMock()
+    landmark_selector.select.return_value = (dest_landmark, dest_image)
+    street_view_image_fetch_service = MagicMock()
+
+    usecase = GenerateRouteUseCase(
+        google_maps_gateway=google_maps_gateway,
+        landmark_search_service=landmark_search_service,
+        landmark_selector=landmark_selector,
+        street_view_image_fetch_service=street_view_image_fetch_service,
+    )
+
+    with (
+        patch(
+            "app.application.usecases.generate_route_usecase.coordinate_service.calculate_distance",
+            return_value=1200,
+        ),
+        patch(
+            "app.application.usecases.generate_route_usecase.coordinate_service.divide_route_into_segments",
+            return_value=[Coordinate(latitude=35.6850, longitude=139.7300)],
+        ),
+        patch(
+            "app.application.usecases.generate_route_usecase.calculate_mission_point_count",
+            return_value=1,
+        ),
+    ):
+        result = usecase.execute(
+            current_coordinate=current_coordinate,
+            radius_m=1000,
+        )
+
+    assert result.midpoints == []
+    assert landmark_selector.select.call_count == 1
+    assert google_maps_gateway.get_directions.call_args_list[1].kwargs["waypoints"] == []


### PR DESCRIPTION
## 概要

Issue #216 に対応し、ルート生成時に中間ミッション地点が最終目的地や既に選んだ中間地点と重複しないよう、`GenerateRouteUseCase` で候補ランドマークをフィルタします。

### ルート生成の位置づけ

<img width="250" alt="mermaid-diagram-2026-04-05-132741" src="https://github.com/user-attachments/assets/b47a2cb9-d482-45a6-a1f7-349d2cd7c455" />

<details><summary>Details</summary>
<pre>
flowchart LR
    subgraph flow["GenerateRouteUseCase の流れ ( 要点 )"]
        A[目的地を決定] --> B[必要な中間地点数を算出]
        B --> C[現在地→目的地のルートを取得し候補座標を等分割]
        C --> D[各候補で Nearby Search]
        D --> E[重複排除して採用]
        E --> F[waypoints 付きで最終ルート取得]
    end
</pre>
</details> 

### 中間地点ランドマークの重複排除

<img width="250" alt="mermaid-diagram-2026-04-05-132805" src="https://github.com/user-attachments/assets/ba408552-1e73-4ea5-9d25-d277d922e63f" />

<details><summary>Details</summary>
<pre>
flowchart TD
    L[Nearby Search の結果リスト] --> F["_filter_midpoint_landmark_candidates"]
    F --> Q{place_id が used_place_ids に含まれる?}
    Q -->|Yes| X[除外: 目的地または既採用と同一 POI]
    Q -->|No| R{候補と目的地の距離が MIDPOINT_DEDUP_MIN_DISTANCE_TO_DESTINATION_M 未満?}
    R -->|Yes| Y[除外: 目的地に極端に近い ( Place ID なし指定先向け )]
    R -->|No| K[採用候補として残す]
    K --> S[landmark_selector で 1 件選択]
    S --> U[used_place_ids に place_id を追加]
</pre>
</details> 

**ルールの要約**

- **Place ID**: 採用済み ( 目的地含む ) と同一の候補を除外する。
- **距離**: 候補の座標と最終目的地座標が `MIDPOINT_DEDUP_MIN_DISTANCE_TO_DESTINATION_M` 未満なら除外する ( ユーザー指定目的地は Place ID が無いため必須 )。
- フィルタ後に候補が無いセグメントは中間地点を付与せず、既存の warning ログに任せる。

関連: #216

## テスト

- `uv run pytest tests/app/application/usecases/test_generate_route_usecase.py` を実行し、該当テストが通過することを確認済み

## 備考

- 図は PR 説明用。コードコメントの代替ではない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**バグ修正**
- ルート生成時に同じ場所が複数回選択されるのを防ぐようになりました
- 目的地に極端に近い途中地点を自動的に除外するようになりました

**テスト**
- ルート生成ロジックの新しい検証テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
