### PR TITLE
fix: Google Maps APIのクォータ上限値を引き下げ

### DIFF
--- a/terraform/env/dev/cloud_quotas.tf
+++ b/terraform/env/dev/cloud_quotas.tf
@@ -14,7 +14,7 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_directio
   parent   = "projects/${local.project_id}"
 
   quota_config {
-    preferred_value = 1000
+    preferred_value = 320
   }
 
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
@@ -28,7 +28,7 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_new_plac
   parent   = "projects/${local.project_id}"
 
   quota_config {
-    preferred_value = 1000
+    preferred_value = 160
   }
 
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
@@ -42,13 +42,13 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_roads_ap
   parent   = "projects/${local.project_id}"
 
   quota_config {
-    preferred_value = 1000
+    preferred_value = 160
   }
 
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
 }
 
-resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_api_from_be" {
+resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_metadata_api" {
   depends_on = [module.snampo_dev]
 
   service  = "street-view-image-backend.googleapis.com"
@@ -62,7 +62,7 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_v
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
 }
 
-resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_api_from_app" {
+resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_static_api" {
   depends_on = [module.snampo_dev]
 
   service  = "street-view-image-backend.googleapis.com"
@@ -70,7 +70,7 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_v
   parent   = "projects/${local.project_id}"
 
   quota_config {
-    preferred_value = 1000
+    preferred_value = 320
   }
 
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"

--- a/terraform/env/prod/cloud_quotas.tf
+++ b/terraform/env/prod/cloud_quotas.tf
@@ -14,7 +14,7 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_directio
   parent   = "projects/${local.project_id}"
 
   quota_config {
-    preferred_value = 1000
+    preferred_value = 320
   }
 
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
@@ -28,7 +28,7 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_new_plac
   parent   = "projects/${local.project_id}"
 
   quota_config {
-    preferred_value = 1000
+    preferred_value = 160
   }
 
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
@@ -42,13 +42,13 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_roads_ap
   parent   = "projects/${local.project_id}"
 
   quota_config {
-    preferred_value = 1000
+    preferred_value = 160
   }
 
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
 }
 
-resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_api_from_be" {
+resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_metadata_api" {
   depends_on = [module.snampo_prod]
 
   service  = "street-view-image-backend.googleapis.com"
@@ -62,7 +62,7 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_v
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
 }
 
-resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_api_from_app" {
+resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_view_static_api" {
   depends_on = [module.snampo_prod]
 
   service  = "street-view-image-backend.googleapis.com"
@@ -70,7 +70,7 @@ resource "google_cloud_quotas_quota_preference" "overall_rate_limit_for_street_v
   parent   = "projects/${local.project_id}"
 
   quota_config {
-    preferred_value = 1000
+    preferred_value = 320
   }
 
   ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"


### PR DESCRIPTION
## 概要
- #228
- Essentials プラン
  - Directions API: 1000 → 320
  - Street View Static API: 1000 → 320
- Pro プラン
  - Roads API: 1000 → 160
  - New Places API: 1000 → 160
- Street View APIリソース名を実態に合わせてリネーム

## テスト
- [x] 該当のquotaが意図通りになってること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 複数のGoogle Cloud APIサービスのクォータ設定を調整しました。Directions、Places、Roads APIのクォータ上限値を削減し、Street View APIのレート制限設定を最適化しました。
  * インフラストラクチャリソースの命名規則を改善し、Street View関連のAPI設定をより明確に区別できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->