### PR TITLE
feat: カメラにズーム機能と16:9クロップを追加

### DIFF
--- a/frontend/lib/features/mission/presentation/page/camera_page.dart
+++ b/frontend/lib/features/mission/presentation/page/camera_page.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:image/image.dart' as img;
 import 'package:loading_animation_widget/loading_animation_widget.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:snampo/features/mission/presentation/dialog/photo_confirm_dialog.dart';
 
 /// カメラページの引数
@@ -35,6 +38,13 @@ class CameraPage extends StatefulWidget {
 class _CameraPageState extends State<CameraPage> {
   CameraController? _controller;
   bool _isInitialized = false;
+  double _minZoomLevel = 1;
+  double _maxZoomLevel = 1;
+  double _currentZoomLevel = 1;
+  double _baseZoomLevel = 1;
+  int _activePointers = 0;
+  bool _isSettingZoomLevel = false;
+  double? _queuedZoomLevel;
 
   @override
   void initState() {
@@ -74,17 +84,34 @@ class _CameraPageState extends State<CameraPage> {
         return;
       }
 
-      _controller = CameraController(
-        cameras.first,
-        ResolutionPreset.medium,
+      final selectedCamera = cameras.firstWhere(
+        (camera) => camera.lensDirection == CameraLensDirection.back,
+        orElse: () => cameras.first,
+      );
+
+      final controller = CameraController(
+        selectedCamera,
+        ResolutionPreset.high,
         enableAudio: false, // 音声録音をしない
       );
 
-      await _controller!.initialize();
+      await controller.initialize();
+      final minZoomLevel = await controller.getMinZoomLevel();
+      final maxZoomLevel = await controller.getMaxZoomLevel();
+      final initialZoomLevel = 1.0.clamp(minZoomLevel, maxZoomLevel).toDouble();
+      await controller.setZoomLevel(initialZoomLevel);
 
-      if (!mounted) return;
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
       setState(() {
+        _controller = controller;
         _isInitialized = true;
+        _minZoomLevel = minZoomLevel;
+        _maxZoomLevel = maxZoomLevel;
+        _currentZoomLevel = initialZoomLevel;
+        _baseZoomLevel = initialZoomLevel;
       });
     } on CameraException catch (e) {
       if (!mounted) return;
@@ -106,6 +133,92 @@ class _CameraPageState extends State<CameraPage> {
     super.dispose();
   }
 
+  void _handleScaleStart(ScaleStartDetails details) {
+    _baseZoomLevel = _currentZoomLevel;
+  }
+
+  Future<void> _handleScaleUpdate(ScaleUpdateDetails details) async {
+    if (_activePointers < 2) {
+      return;
+    }
+
+    final targetZoomLevel = (_baseZoomLevel * details.scale).clamp(
+      _minZoomLevel,
+      _maxZoomLevel,
+    );
+    await _setZoomLevel(targetZoomLevel.toDouble());
+  }
+
+  void _handleScaleEnd(ScaleEndDetails details) {
+    _baseZoomLevel = _currentZoomLevel;
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    _activePointers++;
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    if (_activePointers > 0) {
+      _activePointers--;
+    }
+    if (_activePointers < 2) {
+      _baseZoomLevel = _currentZoomLevel;
+    }
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    if (_activePointers > 0) {
+      _activePointers--;
+    }
+    if (_activePointers < 2) {
+      _baseZoomLevel = _currentZoomLevel;
+    }
+  }
+
+  Future<void> _setZoomLevel(double zoomLevel) async {
+    final controller = _controller;
+    if (controller == null || !_isInitialized) {
+      return;
+    }
+
+    if (_isSettingZoomLevel) {
+      _queuedZoomLevel = zoomLevel;
+      return;
+    }
+
+    _isSettingZoomLevel = true;
+    var nextZoomLevel = zoomLevel;
+
+    while (true) {
+      try {
+        await controller.setZoomLevel(nextZoomLevel);
+      } on CameraException {
+        break;
+      }
+
+      if (!mounted) {
+        _isSettingZoomLevel = false;
+        return;
+      }
+
+      final hasChanged = (_currentZoomLevel - nextZoomLevel).abs() > 0.001;
+      if (hasChanged) {
+        setState(() {
+          _currentZoomLevel = nextZoomLevel;
+        });
+      }
+
+      final queuedZoomLevel = _queuedZoomLevel;
+      _queuedZoomLevel = null;
+      if (queuedZoomLevel == null) {
+        break;
+      }
+      nextZoomLevel = queuedZoomLevel;
+    }
+
+    _isSettingZoomLevel = false;
+  }
+
   @override
   Widget build(BuildContext context) {
     if (!_isInitialized || _controller == null) {
@@ -117,6 +230,8 @@ class _CameraPageState extends State<CameraPage> {
             theme.textTheme.headlineMedium ??
             const TextStyle())
         .copyWith(color: theme.colorScheme.onPrimary);
+    // FAB (56dp) + FAB margin (16dp) + safe area + gap (16dp)
+    final sliderBottom = MediaQuery.paddingOf(context).bottom + 56 + 16 + 16;
 
     return Scaffold(
       appBar: AppBar(
@@ -124,9 +239,100 @@ class _CameraPageState extends State<CameraPage> {
         centerTitle: true,
         backgroundColor: theme.colorScheme.primary,
       ),
-      body: Center(
-        // カメラプレビューを表示
-        child: CameraPreview(_controller!),
+      body: Listener(
+        onPointerDown: _handlePointerDown,
+        onPointerUp: _handlePointerUp,
+        onPointerCancel: _handlePointerCancel,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onScaleStart: _handleScaleStart,
+          onScaleUpdate: _handleScaleUpdate,
+          onScaleEnd: _handleScaleEnd,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              const ColoredBox(color: Colors.black),
+              // カメラプレビューを 16:9 に制限して表示
+              Center(
+                child: AspectRatio(
+                  aspectRatio: 16 / 9,
+                  child: ClipRect(
+                    child: FittedBox(
+                      fit: BoxFit.cover,
+                      child: SizedBox(
+                        width: 1,
+                        height: _controller!.value.aspectRatio,
+                        child: CameraPreview(_controller!),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                top: 16,
+                right: 16,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: Colors.black54,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    child: Text(
+                      '${_currentZoomLevel.toStringAsFixed(1)}x',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: sliderBottom,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Row(
+                    children: [
+                      const Icon(
+                        Icons.zoom_out,
+                        color: Colors.white70,
+                        size: 20,
+                      ),
+                      Expanded(
+                        child: Slider(
+                          value: _currentZoomLevel.clamp(
+                            _minZoomLevel,
+                            _maxZoomLevel,
+                          ),
+                          min: _minZoomLevel,
+                          max: _maxZoomLevel,
+                          onChanged: (value) {
+                            setState(() => _currentZoomLevel = value);
+                            _setZoomLevel(value);
+                          },
+                          activeColor: Colors.white,
+                          inactiveColor: Colors.white38,
+                        ),
+                      ),
+                      const Icon(
+                        Icons.zoom_in,
+                        color: Colors.white70,
+                        size: 20,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
@@ -144,8 +350,53 @@ class _CameraPageState extends State<CameraPage> {
     );
   }
 
+  Future<XFile> _cropTo16x9(XFile original) async {
+    final bytes = await original.readAsBytes();
+    final decoded = img.decodeImage(bytes);
+    if (decoded == null) return original;
+
+    final srcW = decoded.width;
+    final srcH = decoded.height;
+    const targetRatio = 16.0 / 9.0;
+    final srcRatio = srcW / srcH;
+
+    final int cropW;
+    final int cropH;
+    final int cropX;
+    final int cropY;
+
+    if (srcRatio > targetRatio) {
+      cropH = srcH;
+      cropW = (srcH * targetRatio).round().clamp(1, srcW);
+      cropX = (srcW - cropW) ~/ 2;
+      cropY = 0;
+    } else {
+      cropW = srcW;
+      cropH = (srcW / targetRatio).round().clamp(1, srcH);
+      cropX = 0;
+      cropY = (srcH - cropH) ~/ 2;
+    }
+
+    final cropped = img.copyCrop(
+      decoded,
+      x: cropX,
+      y: cropY,
+      width: cropW,
+      height: cropH,
+    );
+    final jpegBytes = img.encodeJpg(cropped, quality: 90);
+
+    final dir = await getTemporaryDirectory();
+    final path =
+        '${dir.path}/snap_${DateTime.now().millisecondsSinceEpoch}.jpg';
+    await File(path).writeAsBytes(jpegBytes);
+
+    return XFile(path);
+  }
+
   Future<void> _handleCapture(BuildContext context) async {
-    final file = await _controller!.takePicture();
+    final rawFile = await _controller!.takePicture();
+    final file = await _cropTo16x9(rawFile);
     if (!context.mounted) {
       return;
     }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -585,7 +585,7 @@ packages:
     source: hosted
     version: "4.1.2"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   google_maps_flutter: ^2.5.3
   hooks_riverpod: ^3.1.0
   http: ^1.2.0
+  image: ^4.8.0
   image_picker: ^1.0.7
   json_annotation: ^4.8.1
   loading_animation_widget: ^1.2.0+4


### PR DESCRIPTION
## 概要
- #222
- ズームスライダーを FAB 上部に追加し、スライダーでも倍率を操作できるようにした
- プレビュー右上に現在の倍率 (`x.x x`) を表示するインジケーターを追加した
- カメラ選択を後カメラ優先 (`CameraLensDirection.back`) に変更し、解像度を `ResolutionPreset.high` に引き上げた
- 撮影後に 16:9 センタークロップを適用し、確認ダイアログおよび採点 API に渡す画像をクロップ後のものに統一した
- プレビュー枠も 16:9 にクリップし、撮影後の見た目と一致させた

## テスト
- [x] 実機でピンチ操作・スライダー操作でズームが効くことを確認
- [x] 撮影後の確認ダイアログに 16:9 の画像が表示されることを確認
- [x] 最小/最大倍率で clamp が正しく機能することを確認
- [x] 撮影→採点フローが従来通り動作することを確認

## 備考
- 光学ズームの可否は端末依存。Android 11+ は `CONTROL_ZOOM_RATIO` API 経由で端末が物理レンズ切替を行う場合がある
- `image` パッケージは間接依存だったため `pubspec.yaml` に直接依存として追加した

### 画面
- 最小倍率
  <img width="300" alt="Screenshot_20260524-022404_1" src="https://github.com/user-attachments/assets/805e6162-1903-4b26-ac26-6553c9bb0d16" />
- 最大倍率
  <img width="300" alt="Screenshot_20260524-022431_1" src="https://github.com/user-attachments/assets/5c499d4e-75d4-412b-a5f4-1b615eabb181" />
- プレビュー
  <img width="300" alt="Screenshot_20260524-022450_1" src="https://github.com/user-attachments/assets/9c8307fa-03b7-449d-ac20-22a18291beae" />
- ミッション画面 (一部)
  <img width="300" alt="Screenshot_20260524-022507_1" src="https://github.com/user-attachments/assets/d08d30b7-1537-4d14-aa44-08af95462ecd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カメラズーム機能を拡張し、ジェスチャ認識によるマルチタッチズーム操作およびスライダー操作に対応しました。
  * カメラプレビューと撮影画像を16:9アスペクト比で統一しました。背面カメラの優先選択に対応。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nakamaware/snampo/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->