### PR TITLE
fix: 値オブジェクトのcopyWithバリデーションバイパスを防止

### DIFF
--- a/frontend/lib/features/mission/domain/entity/mission_entity.freezed.dart
+++ b/frontend/lib/features/mission/domain/entity/mission_entity.freezed.dart
@@ -57,7 +57,7 @@ $Res call({
 });
 
 
-$CoordinateCopyWith<$Res> get departure;$ImageCoordinateCopyWith<$Res> get destination;$RadiusCopyWith<$Res>? get radius;
+$ImageCoordinateCopyWith<$Res> get destination;
 
 }
 /// @nodoc
@@ -84,31 +84,10 @@ as List<ImageCoordinate>,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$CoordinateCopyWith<$Res> get departure {
-  
-  return $CoordinateCopyWith<$Res>(_self.departure, (value) {
-    return _then(_self.copyWith(departure: value));
-  });
-}/// Create a copy of MissionEntity
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
 $ImageCoordinateCopyWith<$Res> get destination {
   
   return $ImageCoordinateCopyWith<$Res>(_self.destination, (value) {
     return _then(_self.copyWith(destination: value));
-  });
-}/// Create a copy of MissionEntity
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$RadiusCopyWith<$Res>? get radius {
-    if (_self.radius == null) {
-    return null;
-  }
-
-  return $RadiusCopyWith<$Res>(_self.radius!, (value) {
-    return _then(_self.copyWith(radius: value));
   });
 }
 }
@@ -306,7 +285,7 @@ $Res call({
 });
 
 
-@override $CoordinateCopyWith<$Res> get departure;@override $ImageCoordinateCopyWith<$Res> get destination;@override $RadiusCopyWith<$Res>? get radius;
+@override $ImageCoordinateCopyWith<$Res> get destination;
 
 }
 /// @nodoc
@@ -334,31 +313,10 @@ as List<ImageCoordinate>,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$CoordinateCopyWith<$Res> get departure {
-  
-  return $CoordinateCopyWith<$Res>(_self.departure, (value) {
-    return _then(_self.copyWith(departure: value));
-  });
-}/// Create a copy of MissionEntity
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
 $ImageCoordinateCopyWith<$Res> get destination {
   
   return $ImageCoordinateCopyWith<$Res>(_self.destination, (value) {
     return _then(_self.copyWith(destination: value));
-  });
-}/// Create a copy of MissionEntity
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$RadiusCopyWith<$Res>? get radius {
-    if (_self.radius == null) {
-    return null;
-  }
-
-  return $RadiusCopyWith<$Res>(_self.radius!, (value) {
-    return _then(_self.copyWith(radius: value));
   });
 }
 }

--- a/frontend/lib/features/mission/domain/entity/mission_progress_entity.freezed.dart
+++ b/frontend/lib/features/mission/domain/entity/mission_progress_entity.freezed.dart
@@ -18,8 +18,8 @@ mixin _$CheckpointProgress {
 /// 撮影時の位置
 @NullableCoordinateConverter() Coordinate? get guessPosition;/// 保存した写真のファイルパス
  String? get userPhotoPath;/// 撮影時の方角
- double? get capturedHeading;/// 位置誤差（メートル）
- double? get distanceErrorMeters;/// 方角誤差（度）
+ double? get capturedHeading;/// 位置誤差 (メートル)
+ double? get distanceErrorMeters;/// 方角誤差 (度)
  double? get headingErrorDegrees;/// 採点ランク
  PhotoJudgeRank? get judgeRank;/// 達成した日時
  DateTime? get achievedAt;
@@ -59,7 +59,7 @@ $Res call({
 });
 
 
-$CoordinateCopyWith<$Res>? get guessPosition;
+
 
 }
 /// @nodoc
@@ -84,19 +84,7 @@ as PhotoJudgeRank?,achievedAt: freezed == achievedAt ? _self.achievedAt : achiev
 as DateTime?,
   ));
 }
-/// Create a copy of CheckpointProgress
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$CoordinateCopyWith<$Res>? get guessPosition {
-    if (_self.guessPosition == null) {
-    return null;
-  }
 
-  return $CoordinateCopyWith<$Res>(_self.guessPosition!, (value) {
-    return _then(_self.copyWith(guessPosition: value));
-  });
-}
 }
 
 
@@ -243,9 +231,9 @@ class _CheckpointProgress implements CheckpointProgress {
 @override final  String? userPhotoPath;
 /// 撮影時の方角
 @override final  double? capturedHeading;
-/// 位置誤差（メートル）
+/// 位置誤差 (メートル)
 @override final  double? distanceErrorMeters;
-/// 方角誤差（度）
+/// 方角誤差 (度)
 @override final  double? headingErrorDegrees;
 /// 採点ランク
 @override final  PhotoJudgeRank? judgeRank;
@@ -289,7 +277,7 @@ $Res call({
 });
 
 
-@override $CoordinateCopyWith<$Res>? get guessPosition;
+
 
 }
 /// @nodoc
@@ -315,19 +303,7 @@ as DateTime?,
   ));
 }
 
-/// Create a copy of CheckpointProgress
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$CoordinateCopyWith<$Res>? get guessPosition {
-    if (_self.guessPosition == null) {
-    return null;
-  }
 
-  return $CoordinateCopyWith<$Res>(_self.guessPosition!, (value) {
-    return _then(_self.copyWith(guessPosition: value));
-  });
-}
 }
 
 

--- a/frontend/lib/features/mission/domain/value_object/coordinate.dart
+++ b/frontend/lib/features/mission/domain/value_object/coordinate.dart
@@ -26,7 +26,7 @@ class CoordinateConverter
 }
 
 /// 座標値オブジェクト
-@freezed
+@Freezed(copyWith: false)
 abstract class Coordinate with _$Coordinate {
   /// 座標を作成する
   ///

--- a/frontend/lib/features/mission/domain/value_object/coordinate.freezed.dart
+++ b/frontend/lib/features/mission/domain/value_object/coordinate.freezed.dart
@@ -15,11 +15,6 @@ T _$identity<T>(T value) => value;
 mixin _$Coordinate {
 
  double get latitude; double get longitude;
-/// Create a copy of Coordinate
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$CoordinateCopyWith<Coordinate> get copyWith => _$CoordinateCopyWithImpl<Coordinate>(this as Coordinate, _$identity);
 
 
 
@@ -40,37 +35,7 @@ String toString() {
 
 }
 
-/// @nodoc
-abstract mixin class $CoordinateCopyWith<$Res>  {
-  factory $CoordinateCopyWith(Coordinate value, $Res Function(Coordinate) _then) = _$CoordinateCopyWithImpl;
-@useResult
-$Res call({
- double latitude, double longitude
-});
 
-
-
-
-}
-/// @nodoc
-class _$CoordinateCopyWithImpl<$Res>
-    implements $CoordinateCopyWith<$Res> {
-  _$CoordinateCopyWithImpl(this._self, this._then);
-
-  final Coordinate _self;
-  final $Res Function(Coordinate) _then;
-
-/// Create a copy of Coordinate
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? latitude = null,Object? longitude = null,}) {
-  return _then(_self.copyWith(
-latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
-as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
-as double,
-  ));
-}
-
-}
 
 
 /// Adds pattern-matching-related methods to [Coordinate].
@@ -213,11 +178,6 @@ class _Coordinate extends Coordinate {
 @override final  double latitude;
 @override final  double longitude;
 
-/// Create a copy of Coordinate
-/// with the given fields replaced by the non-null parameter values.
-@override @JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-_$CoordinateCopyWith<_Coordinate> get copyWith => __$CoordinateCopyWithImpl<_Coordinate>(this, _$identity);
 
 
 
@@ -238,37 +198,7 @@ String toString() {
 
 }
 
-/// @nodoc
-abstract mixin class _$CoordinateCopyWith<$Res> implements $CoordinateCopyWith<$Res> {
-  factory _$CoordinateCopyWith(_Coordinate value, $Res Function(_Coordinate) _then) = __$CoordinateCopyWithImpl;
-@override @useResult
-$Res call({
- double latitude, double longitude
-});
 
 
-
-
-}
-/// @nodoc
-class __$CoordinateCopyWithImpl<$Res>
-    implements _$CoordinateCopyWith<$Res> {
-  __$CoordinateCopyWithImpl(this._self, this._then);
-
-  final _Coordinate _self;
-  final $Res Function(_Coordinate) _then;
-
-/// Create a copy of Coordinate
-/// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? latitude = null,Object? longitude = null,}) {
-  return _then(_Coordinate(
-latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
-as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
-as double,
-  ));
-}
-
-
-}
 
 // dart format on

--- a/frontend/lib/features/mission/domain/value_object/image_coordinate.freezed.dart
+++ b/frontend/lib/features/mission/domain/value_object/image_coordinate.freezed.dart
@@ -58,7 +58,7 @@ $Res call({
 });
 
 
-$CoordinateCopyWith<$Res> get coordinate;
+
 
 }
 /// @nodoc
@@ -82,16 +82,7 @@ as String?,googleMapsUrl: freezed == googleMapsUrl ? _self.googleMapsUrl : googl
 as String?,
   ));
 }
-/// Create a copy of ImageCoordinate
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$CoordinateCopyWith<$Res> get coordinate {
 
-  return $CoordinateCopyWith<$Res>(_self.coordinate, (value) {
-    return _then(_self.copyWith(coordinate: value));
-  });
-}
 }
 
 
@@ -282,7 +273,7 @@ $Res call({
 });
 
 
-@override $CoordinateCopyWith<$Res> get coordinate;
+
 
 }
 /// @nodoc
@@ -307,16 +298,7 @@ as String?,
   ));
 }
 
-/// Create a copy of ImageCoordinate
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$CoordinateCopyWith<$Res> get coordinate {
 
-  return $CoordinateCopyWith<$Res>(_self.coordinate, (value) {
-    return _then(_self.copyWith(coordinate: value));
-  });
-}
 }
 
 // dart format on

--- a/frontend/lib/features/mission/domain/value_object/radius.dart
+++ b/frontend/lib/features/mission/domain/value_object/radius.dart
@@ -19,7 +19,7 @@ class RadiusConverter implements JsonConverter<Radius, Map<String, dynamic>> {
 }
 
 /// 半径値オブジェクト
-@freezed
+@Freezed(copyWith: false)
 abstract class Radius with _$Radius {
   /// 半径を作成する
   ///

--- a/frontend/lib/features/mission/domain/value_object/radius.freezed.dart
+++ b/frontend/lib/features/mission/domain/value_object/radius.freezed.dart
@@ -15,11 +15,6 @@ T _$identity<T>(T value) => value;
 mixin _$Radius {
 
  int get meters;
-/// Create a copy of Radius
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$RadiusCopyWith<Radius> get copyWith => _$RadiusCopyWithImpl<Radius>(this as Radius, _$identity);
 
 
 
@@ -40,36 +35,7 @@ String toString() {
 
 }
 
-/// @nodoc
-abstract mixin class $RadiusCopyWith<$Res>  {
-  factory $RadiusCopyWith(Radius value, $Res Function(Radius) _then) = _$RadiusCopyWithImpl;
-@useResult
-$Res call({
- int meters
-});
 
-
-
-
-}
-/// @nodoc
-class _$RadiusCopyWithImpl<$Res>
-    implements $RadiusCopyWith<$Res> {
-  _$RadiusCopyWithImpl(this._self, this._then);
-
-  final Radius _self;
-  final $Res Function(Radius) _then;
-
-/// Create a copy of Radius
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? meters = null,}) {
-  return _then(_self.copyWith(
-meters: null == meters ? _self.meters : meters // ignore: cast_nullable_to_non_nullable
-as int,
-  ));
-}
-
-}
 
 
 /// Adds pattern-matching-related methods to [Radius].
@@ -211,11 +177,6 @@ class _Radius extends Radius {
 
 @override final  int meters;
 
-/// Create a copy of Radius
-/// with the given fields replaced by the non-null parameter values.
-@override @JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-_$RadiusCopyWith<_Radius> get copyWith => __$RadiusCopyWithImpl<_Radius>(this, _$identity);
 
 
 
@@ -236,36 +197,7 @@ String toString() {
 
 }
 
-/// @nodoc
-abstract mixin class _$RadiusCopyWith<$Res> implements $RadiusCopyWith<$Res> {
-  factory _$RadiusCopyWith(_Radius value, $Res Function(_Radius) _then) = __$RadiusCopyWithImpl;
-@override @useResult
-$Res call({
- int meters
-});
 
 
-
-
-}
-/// @nodoc
-class __$RadiusCopyWithImpl<$Res>
-    implements _$RadiusCopyWith<$Res> {
-  __$RadiusCopyWithImpl(this._self, this._then);
-
-  final _Radius _self;
-  final $Res Function(_Radius) _then;
-
-/// Create a copy of Radius
-/// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? meters = null,}) {
-  return _then(_Radius(
-meters: null == meters ? _self.meters : meters // ignore: cast_nullable_to_non_nullable
-as int,
-  ));
-}
-
-
-}
 
 // dart format on

--- a/frontend/lib/features/mission/presentation/store/mission_progress_store.g.dart
+++ b/frontend/lib/features/mission/presentation/store/mission_progress_store.g.dart
@@ -43,7 +43,7 @@ final class MissionProgressStoreNotifierProvider
 }
 
 String _$missionProgressStoreNotifierHash() =>
-    r'48c15ba0756feccf7461cf52ae7cec142ffdb17d';
+    r'bb386f228c49bfbc1e68837d94b2fc13ecc376c8';
 
 /// ミッション進捗を管理するストア
 

--- a/frontend/lib/features/mission/presentation/store/mission_store.freezed.dart
+++ b/frontend/lib/features/mission/presentation/store/mission_store.freezed.dart
@@ -220,7 +220,7 @@ $Res call({
 });
 
 
-$RadiusCopyWith<$Res> get radius;
+
 
 }
 /// @nodoc
@@ -240,16 +240,7 @@ as Radius,
   ));
 }
 
-/// Create a copy of MissionStoreParams
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$RadiusCopyWith<$Res> get radius {
-  
-  return $RadiusCopyWith<$Res>(_self.radius, (value) {
-    return _then(_self.copyWith(radius: value));
-  });
-}
+
 }
 
 /// @nodoc
@@ -295,7 +286,7 @@ $Res call({
 });
 
 
-$CoordinateCopyWith<$Res> get destination;
+
 
 }
 /// @nodoc
@@ -315,16 +306,7 @@ as Coordinate,
   ));
 }
 
-/// Create a copy of MissionStoreParams
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$CoordinateCopyWith<$Res> get destination {
-  
-  return $CoordinateCopyWith<$Res>(_self.destination, (value) {
-    return _then(_self.copyWith(destination: value));
-  });
-}
+
 }
 
 /// @nodoc

--- a/frontend/test/features/mission/domain/value_object/value_object_validation_test.dart
+++ b/frontend/test/features/mission/domain/value_object/value_object_validation_test.dart
@@ -37,7 +37,6 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
     });
-
   });
 
   group('Radius', () {
@@ -56,6 +55,5 @@ void main() {
       expect(() => Radius(meters: 499), throwsA(isA<ArgumentError>()));
       expect(() => Radius(meters: 10001), throwsA(isA<ArgumentError>()));
     });
-
   });
 }

--- a/frontend/test/features/mission/domain/value_object/value_object_validation_test.dart
+++ b/frontend/test/features/mission/domain/value_object/value_object_validation_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snampo/features/mission/domain/value_object/coordinate.dart';
+import 'package:snampo/features/mission/domain/value_object/radius.dart';
+
+void main() {
+  group('Coordinate', () {
+    test('有効な範囲の値で生成できる', () {
+      final value = Coordinate(latitude: 35.681236, longitude: 139.767125);
+
+      expect(value.latitude, 35.681236);
+      expect(value.longitude, 139.767125);
+    });
+
+    test('境界値で生成できる', () {
+      expect(() => Coordinate(latitude: -90, longitude: -180), returnsNormally);
+      expect(() => Coordinate(latitude: 90, longitude: 180), returnsNormally);
+    });
+
+    test('範囲外の緯度で生成すると ArgumentError', () {
+      expect(
+        () => Coordinate(latitude: 90.1, longitude: 0),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => Coordinate(latitude: -90.1, longitude: 0),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('範囲外の経度で生成すると ArgumentError', () {
+      expect(
+        () => Coordinate(latitude: 0, longitude: 180.1),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => Coordinate(latitude: 0, longitude: -180.1),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+  });
+
+  group('Radius', () {
+    test('有効な範囲の値で生成できる', () {
+      final value = Radius(meters: 5000);
+
+      expect(value.meters, 5000);
+    });
+
+    test('境界値で生成できる', () {
+      expect(() => Radius(meters: 500), returnsNormally);
+      expect(() => Radius(meters: 10000), returnsNormally);
+    });
+
+    test('範囲外の値で生成すると ArgumentError', () {
+      expect(() => Radius(meters: 499), throwsA(isA<ArgumentError>()));
+      expect(() => Radius(meters: 10001), throwsA(isA<ArgumentError>()));
+    });
+
+  });
+}


### PR DESCRIPTION
## 概要
値のバリデーションを含む `Coordinate` と `Radius` オブジェクトから `copyWith` を削除しました。
バリデーション回避による予期せぬエラーの未然防止になると思います。
ついでに `Coordinate` と `Radius` のバリデーションテストコードを追加しました。


## 実施内容
- `Coordinate` / `Radius` を `@Freezed(copyWith: false)` に変更
- `build_runner` 再生成により、関連する Freezed 生成コードの nested copyWith 定義を更新
- 値オブジェクトのバリデーションテストを追加し、境界値と範囲外値の挙動を検証

## Test plan
- [x] `dart run build_runner build --delete-conflicting-outputs`
- [x] `flutter analyze` (既存 info のみ)
- [x] `flutter test test/features/mission/domain/value_object/value_object_validation_test.dart`

## 動作確認
- ローカルでバックエンド、仮想マシン上でフロントエンドを立ち上げて、半径を0.5km、10kmにして正常にゲーム開始、終了ができることを確認

## 関連Issue
[#163 ](https://github.com/nakamaware/snampo/issues/163#issue-3824759257)


Made with [Cursor](https://cursor.com)