### PR TITLE
fix: router.dartにてエラー処理を追加

### DIFF
--- a/frontend/lib/core/router.dart
+++ b/frontend/lib/core/router.dart
@@ -1,10 +1,14 @@
 import 'package:go_router/go_router.dart';
 import 'package:snampo/features/home/presentation/page/home_page.dart';
 import 'package:snampo/features/mission/presentation/page/camera_page.dart';
-import 'package:snampo/features/mission/presentation/page/spot_result_page.dart';
 import 'package:snampo/features/mission/presentation/page/mission_page.dart';
 import 'package:snampo/features/mission/presentation/page/result_page.dart';
 import 'package:snampo/features/mission/presentation/page/setup_page.dart';
+import 'package:snampo/features/mission/presentation/page/spot_result_page.dart';
+
+HomePage _homeWithError(String message) {
+  return HomePage(errorMessage: message);
+}
 
 /// ルーティング設定
 final GoRouter appRouter = GoRouter(
@@ -14,7 +18,10 @@ final GoRouter appRouter = GoRouter(
     GoRoute(
       path: '/mission/random/:radius',
       builder: (context, state) {
-        final meters = int.parse(state.pathParameters['radius']!);
+        final meters = int.tryParse(state.pathParameters['radius'] ?? '');
+        if (meters == null) {
+          return _homeWithError('無効なリンクです');
+        }
         return MissionPage(radius: meters);
       },
     ),
@@ -27,7 +34,7 @@ final GoRouter appRouter = GoRouter(
       builder: (context, state) {
         final extra = state.extra;
         if (extra is! CameraPageArgs) {
-          return const HomePage();
+          return _homeWithError('無効なリンクです');
         }
         return CameraPage(args: extra);
       },
@@ -37,7 +44,7 @@ final GoRouter appRouter = GoRouter(
       builder: (context, state) {
         final extra = state.extra;
         if (extra is! SpotResultPageArgs) {
-          return const HomePage();
+          return _homeWithError('無効なリンクです');
         }
         return SpotResultPage(args: extra);
       },
@@ -45,8 +52,11 @@ final GoRouter appRouter = GoRouter(
     GoRoute(
       path: '/mission/destination/:lat/:lng',
       builder: (context, state) {
-        final lat = double.parse(state.pathParameters['lat']!);
-        final lng = double.parse(state.pathParameters['lng']!);
+        final lat = double.tryParse(state.pathParameters['lat'] ?? '');
+        final lng = double.tryParse(state.pathParameters['lng'] ?? '');
+        if (lat == null || lng == null) {
+          return _homeWithError('無効なリンクです');
+        }
         return MissionPage.withDestination(
           destinationLat: lat,
           destinationLng: lng,
@@ -55,4 +65,7 @@ final GoRouter appRouter = GoRouter(
     ),
     GoRoute(path: '/result', builder: (context, state) => const ResultPage()),
   ],
+  errorBuilder: (context, state) {
+    return _homeWithError('存在しないページです');
+  },
 );

--- a/frontend/lib/features/home/presentation/page/home_page.dart
+++ b/frontend/lib/features/home/presentation/page/home_page.dart
@@ -1,15 +1,40 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:snampo/features/mission/presentation/store/persisted_mission_provider.dart';
 
 /// アプリケーションのトップページ
-class HomePage extends ConsumerWidget {
+class HomePage extends HookConsumerWidget {
   /// HomePageのコンストラクタ
-  const HomePage({super.key});
+  const HomePage({super.key, this.errorMessage});
+
+  /// エラー表示に使うメッセージ
+  final String? errorMessage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    useEffect(() {
+      final message = errorMessage;
+      if (message == null || message.isEmpty) {
+        return null;
+      }
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) {
+          return;
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(message),
+            duration: const Duration(seconds: 5),
+          ),
+        );
+      });
+
+      return null;
+    }, [errorMessage]);
+
     final savedMissionAsync = ref.watch(persistedMissionProvider);
     final hasSavedMission = savedMissionAsync.value != null;
 


### PR DESCRIPTION
# 概要
#156 に関連し、router.dartにてエラー発生時にはHomePageに遷移し、HomePageにてSnackBarでエラーを表示する処理を追加した。

# 変更ファイル
- router.dart
- home_page.dart

# 試験内容
検討中