### PR TITLE
chore: 開発環境(dev)においてAPI_BASE_URLの自動設定機能の追加

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,17 +1,27 @@
 # .env設定ファイルのサンプル
-# このファイルを .env としてコピーし、各値を自身のプロジェクト用に設定してください。
-# コマンド例: cp .env.example .env
-#
-# 各種APIキーなどはiOS/Androidの両方で使用されます
-#
-# FLAVOR: 環境の名前 (必須) (例: dev, prod)
-# GOOGLE_MAP_API_KEY: Google Maps APIキー
-# API_BASE_URL: APIのベースURL (FLAVOR が dev のときは 任意、それ以外は 必須)
-#   - 開発環境: 空 にすると、OSに応じて以下の値として実行される
-#   - 開発環境 (Android): http://10.0.2.2:8000
-#   - 開発環境 (iOS): http://localhost:8000
-#   - 本番環境: https://hoge-fuga.asia-northeast1.run.app
+# このファイルを .env としてコピーして使用すること（コマンド例: cp .env.example .env）
 
+# ------------------------------------------------------------------------------
+# 1. 基本設定
+# ------------------------------------------------------------------------------
+# FLAVOR: 環境の識別子 (必須) [値: dev / prod]
 FLAVOR=dev
+
+# GOOGLE_MAP_API_KEY: Google Maps APIキー (必須)
 GOOGLE_MAP_API_KEY=your_google_maps_api_key_here
-API_BASE_URL=your_api_base_url_here
+
+# ------------------------------------------------------------------------------
+# 2. ネットワーク設定
+# ------------------------------------------------------------------------------
+# API_BASE_URL: APIサーバーのベースURL
+#
+# ■ FLAVOR=dev (開発環境) の場合:
+#   値を「空」にすると、実行OSに応じて以下のローカルURLに自動フォールバックされる
+#   - Androidエミュレータ: http://10.0.2.2:8000
+#   - iOSシミュレータ:     http://localhost:8000
+#   ※ 特定のローカルIPや外部サーバーに接続したい場合のみ、URLを記述すること
+#
+# ■ FLAVOR=prod (本番環境) の場合:
+#   必須項目。本番用のAPI URL（例: https://hoge-fuga.run.app）の指定が必要
+#
+API_BASE_URL=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,9 +4,10 @@
 #
 # 各種APIキーなどはiOS/Androidの両方で使用されます
 #
-# FLAVOR: 環境の名前 (例: dev, prod)
+# FLAVOR: 環境の名前 (必須) (例: dev, prod)
 # GOOGLE_MAP_API_KEY: Google Maps APIキー
-# API_BASE_URL: APIのベースURL
+# API_BASE_URL: APIのベースURL (FLAVOR が dev のときは 任意、それ以外は 必須)
+#   - 開発環境: 空 にすると、OSに応じて以下の値として実行される
 #   - 開発環境 (Android): http://10.0.2.2:8000
 #   - 開発環境 (iOS): http://localhost:8000
 #   - 本番環境: https://hoge-fuga.asia-northeast1.run.app

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
 # .env設定ファイルのサンプル
-# このファイルを .env としてコピーして使用すること（コマンド例: cp .env.example .env）
+# このファイルを .env としてコピーして使用すること (コマンド例: cp .env.example .env)
 
 # ------------------------------------------------------------------------------
 # 1. 基本設定
@@ -22,6 +22,6 @@ GOOGLE_MAP_API_KEY=your_google_maps_api_key_here
 #   ※ 特定のローカルIPや外部サーバーに接続したい場合のみ、URLを記述すること
 #
 # ■ FLAVOR=prod (本番環境) の場合:
-#   必須項目。本番用のAPI URL（例: https://hoge-fuga.run.app）の指定が必要
+#   必須項目。本番用のAPI URL (例: https://hoge-fuga.run.app) の指定が必要
 #
 API_BASE_URL=

--- a/frontend/lib/config.dart
+++ b/frontend/lib/config.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 /// 環境設定を管理するクラス
 ///
 /// ビルド時に `--dart-define` で値を渡すことで環境ごとの設定を切り替えます
@@ -20,10 +22,21 @@ class Env {
   static String get apiBaseUrl {
     const value = String.fromEnvironment('API_BASE_URL');
     if (value.isEmpty) {
-      throw StateError(
-        'API_BASE_URL環境変数が設定されていません。'
-        'ビルド時に `--dart-define=API_BASE_URL=http://example.com` のように指定してください。',
-      );
+      // API_BASE_URL が空 かつ 環境がdev かつ Android のとき
+      if (flavor == 'dev' && Platform.isAndroid) {
+        return 'http://10.0.2.2:8000';
+      }
+      // API_BASE_URL が空 かつ 環境がdev かつ iOS のとき
+      else if (flavor == 'dev' && Platform.isIOS) {
+        return 'http://localhost:8000';
+      }
+      // それ以外のときは API_BASE_URLが空だとエラー
+      else {
+        throw StateError(
+          'API_BASE_URL環境変数が設定されていません。'
+          'ビルド時に `--dart-define=API_BASE_URL=http://example.com` のように指定してください。',
+        );
+      }
     }
     return value;
   }


### PR DESCRIPTION
# 概要
Android/iOSのローカルデバッグにおいて、.env 内の API_BASE_URL を毎回手動で書き換える手間を解消するため、config.dart 内で実行OS（Android/iOS）に応じたURLへ自動でフォールバックするロジックを実装しました。
なお、 #68 で検討していた `.vscode/launch.json` を複数用意する（OSごとに起動構成を分ける）アプローチではなく、起動構成は1つのままコード側で判別する方針へ変更してます。

# 変更内容
1. `config.dart` (`Env` クラス) の修正
- `API_BASE_URL` が未指定（空文字）かつ `FLAVOR == 'dev'` の場合、以下の通り自動で読み替えるロジックを追加
  - Android: http://10.0.2.2:8000
  - iOS: http://localhost:8000
- ただし、 `FLAVOR == 'prod'` など、開発環境以外で `API_BASE_URL` が空の場合は、従来どおり `StateError` をスローする。

2. `.env.example` の更新
- 開発環境（dev）において `API_BASE_URL` を空にすると自動判別が動く旨をコメントとして追記
- その他、見やすいように整理

# レビュー観点
[ ] config.dart の条件分岐（Android / iOS / エラーハンドリング）のロジックに問題がないか
[ ] .env.example の説明文がチームメンバーにとって分かりやすいか

# 備考
この変更により、ローカルデバッグ時は `.env` から `API_BASE_URL=your_api_base_url_here` の行を削る（または空にする、コメントアウトする）と、OSを問わずそのままデバッグ起動できるようになります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 環境変数設定ファイルの説明を日本語で詳細化し、各設定項目の使用方法を明確にしました。

* **新機能**
  * 開発環境においてプラットフォーム（AndroidとiOS）に応じたAPI URLの自動フォールバック機能を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nakamaware/snampo/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->