### PR TITLE
fix: 請求先アカウントの読み取り権限を追加

### DIFF
--- a/terraform/env/dev/.terraform.lock.hcl
+++ b/terraform/env/dev/.terraform.lock.hcl
@@ -1,10 +1,31 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.8.0"
+  hashes = [
+    "h1:i4jOdktQW0SDbjM3IC2ZSqdd881FzVY+V11XKkLPHrk=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "7.15.0"
   constraints = ">= 3.43.0, >= 4.83.0, >= 5.26.0, >= 6.37.0, ~> 7.15.0, < 8.0.0"
   hashes = [
+    "h1:JMqoemYaZPvkMk1MjlMxkodfcXbRcp9a+vA5f0s5tKY=",
     "h1:JjelrMNfs4sYlCFRFagTRfDw0wGWQe2rpPgsyhs76U4=",
     "h1:v4XbUGWLnWPhYBQVgwCuzj4/BlhgVzDKjm6Eqlpa/zE=",
     "zh:0f1b4ebaae76bcf9f3cd783dbf43d488f5b1bb8443acb78e0d409cf7c72e5fb0",
@@ -28,6 +49,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   hashes = [
     "h1:AYkbr/tWMlls9wZ6XzXzOOPHt+vR+2RQHBzqbiZnm1Q=",
     "h1:Vpu4tOGNsV/4tQSrKE1lgmgyPtdvVNdYP3ufIZjh0gI=",
+    "h1:rDrgVREDpvt53rW+KJrwDzZUsoFJBIO6w+lrkIhxuyM=",
     "zh:019e52991b04abab4e73eef421ffeaf45d3647e197289dffc604a56cb0de2c42",
     "zh:4bc9fb229b77409b1bd535aed91f1c054811c8c23f39e4dc0dd9d6aa39cc708d",
     "zh:63d7d0bedddd2d43bdba01ba94425533849f51e58a6e4e1652f1c81adbee0b9f",
@@ -47,6 +69,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.7.2"
   constraints = ">= 2.1.0"
   hashes = [
+    "h1:0hcNr59VEJbhZYwuDE/ysmyTS0evkfcLarlni+zATPM=",
     "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
     "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
     "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",

--- a/terraform/env/dev/budget.tf
+++ b/terraform/env/dev/budget.tf
@@ -23,9 +23,19 @@ variable "discord_webhook_url" {
 # 予算アラート
 # ------------------------------
 
+# 初回適用時のみ Billing Account Admin 権限による手動付与が必要
+resource "google_billing_account_iam_member" "terraform_costs_manager" {
+  billing_account_id = var.billing_account_id
+  role               = "roles/billing.costsManager"
+  member             = "serviceAccount:${local.project_name}-terraform@${local.project_id}.iam.gserviceaccount.com"
+
+  depends_on = [module.snampo_dev]
+}
+
 data "google_billing_account" "account" {
   billing_account = var.billing_account_id
-  depends_on      = [module.snampo_dev]
+  lookup_projects = false
+  depends_on      = [google_billing_account_iam_member.terraform_costs_manager]
 }
 
 resource "google_monitoring_notification_channel" "email" {


### PR DESCRIPTION
#234 で権限不足があっため追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Terraform プロバイダーの依存関係ロック情報を更新しました（Archive プロバイダーおよび他のプロバイダーのハッシュ値を追加）
  * GCP 請求アカウントのアクセス権限設定を更新し、請求データ取得の依存関係を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->