### PR TITLE
feat: Apple Maps 層別クエリで目的地ランドマーク検索 (#235)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,14 +3,18 @@ ENV=dev
 # Get your API key from: https://console.cloud.google.com/google/maps-apis
 GOOGLE_API_KEY=your_google_maps_api_key_here
 
-# Apple Maps Server API (検索スパイク / probe_apple_maps_search.py 用。本番ルート生成には未接続)
+# Apple Maps Server API (目的地ランドマーク検索)
 # 手順: https://developer.apple.com/documentation/applemapsserverapi/creating-a-maps-identifier-and-a-private-key
 # 1. Identifiers → Maps IDs で Maps ID を作成 (例: maps.com.example.snampo)
 # 2. Keys → MapKit JS を有効化し、上記 Maps ID を Configure で紐づけて .p8 を Download
 # 3. Membership の Team ID と Keys の Key ID を控える
 APPLE_TEAM_ID=your_10_char_team_id
 APPLE_MAPS_KEY_ID=your_10_char_key_id
-# Maps ID (Services ID)。鍵作成時の紐づけ用。JWT の claims には含めない (任意だが手順の追跡用に記載)。
+# Maps ID (Services ID)。鍵作成時の紐づけ用。JWT の claims には含めない (任意)。
 APPLE_MAPS_ID=maps.com.example.snampo
-# .p8 は git 管理外 (backend/secrets/ 推奨)。backend/ からの相対パス可。
+
+# 秘密鍵 (どちらか一方で可。Cloud Run は PEM 環境変数、ローカルは .p8 パスを推奨)
+# Cloud Run / Secret Manager: PEM 文字列全体 (-----BEGIN PRIVATE KEY----- ... )
+# APPLE_MAPS_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+# ローカル: .p8 は git 管理外 (backend/secrets/ 推奨)。backend/ からの相対パス可。
 APPLE_MAPS_PRIVATE_KEY_PATH=secrets/apple-maps/AuthKey_XXXXXXXXXX.p8

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,15 @@ ENV=dev
 # Google Maps API Key
 # Get your API key from: https://console.cloud.google.com/google/maps-apis
 GOOGLE_API_KEY=your_google_maps_api_key_here
+
+# Apple Maps Server API (検索スパイク / probe_apple_maps_search.py 用。本番ルート生成には未接続)
+# 手順: https://developer.apple.com/documentation/applemapsserverapi/creating-a-maps-identifier-and-a-private-key
+# 1. Identifiers → Maps IDs で Maps ID を作成 (例: maps.com.example.snampo)
+# 2. Keys → MapKit JS を有効化し、上記 Maps ID を Configure で紐づけて .p8 を Download
+# 3. Membership の Team ID と Keys の Key ID を控える
+APPLE_TEAM_ID=your_10_char_team_id
+APPLE_MAPS_KEY_ID=your_10_char_key_id
+# Maps ID (Services ID)。鍵作成時の紐づけ用。JWT の claims には含めない (任意だが手順の追跡用に記載)。
+APPLE_MAPS_ID=maps.com.example.snampo
+# .p8 は git 管理外 (backend/secrets/ 推奨)。backend/ からの相対パス可。
+APPLE_MAPS_PRIVATE_KEY_PATH=secrets/apple-maps/AuthKey_XXXXXXXXXX.p8

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -217,3 +217,7 @@ __marimo__/
 
 # Project specific
 route.html
+apple_maps_probe_result.json
+apple_maps_search_probe_result.json
+secrets/
+*.p8

--- a/backend/app/application/gateway_interfaces/__init__.py
+++ b/backend/app/application/gateway_interfaces/__init__.py
@@ -3,9 +3,18 @@
 外部サービスへのインターフェースを定義します。
 """
 
+from app.application.gateway_interfaces.apple_maps_gateway import (
+    AppleMapsGateway,
+    AppleSearchHit,
+)
 from app.application.gateway_interfaces.google_maps_gateway import (
     GoogleMapsGateway,
     StreetViewMetadata,
 )
 
-__all__ = ["GoogleMapsGateway", "StreetViewMetadata"]
+__all__ = [
+    "AppleMapsGateway",
+    "AppleSearchHit",
+    "GoogleMapsGateway",
+    "StreetViewMetadata",
+]

--- a/backend/app/application/gateway_interfaces/apple_maps_gateway.py
+++ b/backend/app/application/gateway_interfaces/apple_maps_gateway.py
@@ -1,7 +1,6 @@
-"""Apple Maps Server API Gateway ポート (検索スパイク用)
+"""Apple Maps Server API Gateway ポート (目的地ランドマーク検索)
 
-本番の GenerateRouteUseCase / GoogleMapsGateway には接続しない。
-カテゴリ検索 + クエリバッグフォールバックの品質検証専用。
+Directions / Street View / Roads は GoogleMapsGateway のまま。
 """
 
 from __future__ import annotations
@@ -12,7 +11,7 @@ from typing import Literal
 
 from app.domain.value_objects import Coordinate, Landmark
 
-AppleSearchSource = Literal["category", "query"]
+AppleSearchSource = Literal["query", "fanout"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,14 +48,16 @@ class AppleMapsGateway(ABC):
         *,
         target_count: int | None = None,
         distance_tolerance_percent: float | None = None,
+        max_calls: int | None = None,
     ) -> list[AppleSearchHit]:
-        """中心 + 半径を bbox 近似し、カテゴリ検索 → 不足時クエリバッグで POI を探す。
+        """層別クエリ + ファンアウトで距離帯内のランドマークを検索する。
 
         Args:
-            coordinate: 検索中心
+            coordinate: 検索中心 (目的地リングの中心 = 現在地)
             radius_m: 目標距離 (メートル)。±tolerance% の距離帯でフィルタする。
-            target_count: フォールバック発動閾値 (未指定時は設定値)
+            target_count: 目標件数 (未指定時は設定値)
             distance_tolerance_percent: 距離帯の許容 % (未指定時は設定値)
+            max_calls: Apple /v1/search の最大呼び出し回数 (未指定時は設定値)
 
         Returns:
             list[AppleSearchHit]: place_id は `apple:<id>` 形式で dedup 済み

--- a/backend/app/application/gateway_interfaces/apple_maps_gateway.py
+++ b/backend/app/application/gateway_interfaces/apple_maps_gateway.py
@@ -1,0 +1,64 @@
+"""Apple Maps Server API Gateway ポート (検索スパイク用)
+
+本番の GenerateRouteUseCase / GoogleMapsGateway には接続しない。
+カテゴリ検索 + クエリバッグフォールバックの品質検証専用。
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Literal
+
+from app.domain.value_objects import Coordinate, Landmark
+
+AppleSearchSource = Literal["category", "query"]
+
+
+@dataclass(frozen=True, slots=True)
+class AppleSearchHit:
+    """Apple 検索の 1 ヒット (距離帯フィルタ後)"""
+
+    place_id: str
+    display_name: str
+    coordinate: Coordinate
+    distance_m: float
+    source: AppleSearchSource
+    poi_category: str | None = None
+
+    def to_landmark(self) -> Landmark:
+        """既存 Landmark VO へ変換する。"""
+        types = [self.poi_category] if self.poi_category else None
+        return Landmark(
+            place_id=self.place_id,
+            display_name=self.display_name,
+            coordinate=self.coordinate,
+            primary_type=self.poi_category,
+            types=types,
+        )
+
+
+class AppleMapsGateway(ABC):
+    """Apple Maps Server API 検索ポート"""
+
+    @abstractmethod
+    def search_landmarks_nearby(
+        self,
+        coordinate: Coordinate,
+        radius_m: int,
+        *,
+        target_count: int | None = None,
+        distance_tolerance_percent: float | None = None,
+    ) -> list[AppleSearchHit]:
+        """中心 + 半径を bbox 近似し、カテゴリ検索 → 不足時クエリバッグで POI を探す。
+
+        Args:
+            coordinate: 検索中心
+            radius_m: 目標距離 (メートル)。±tolerance% の距離帯でフィルタする。
+            target_count: フォールバック発動閾値 (未指定時は設定値)
+            distance_tolerance_percent: 距離帯の許容 % (未指定時は設定値)
+
+        Returns:
+            list[AppleSearchHit]: place_id は `apple:<id>` 形式で dedup 済み
+        """
+        raise NotImplementedError

--- a/backend/app/application/services/landmark_search_service.py
+++ b/backend/app/application/services/landmark_search_service.py
@@ -1,23 +1,16 @@
 """ランドマーク検索アプリケーションサービス
 
-ランドマーク検索のオーケストレーションを提供します。
+目的地選定向けのランドマーク検索オーケストレーションを提供します。
+Apple Maps Server API の層別クエリ + ファンアウトを利用します。
+(中間地点検索・Directions・Street View は GoogleMapsGateway のまま)
 """
 
 import logging
 
 from injector import inject
 
-from app.application.gateway_interfaces.google_maps_gateway import GoogleMapsGateway
-from app.config import (
-    LANDMARK_DISTANCE_TOLERANCE_PERCENT,
-    MIN_SEARCH_RADIUS_M,
-)
+from app.application.gateway_interfaces.apple_maps_gateway import AppleMapsGateway
 from app.domain.exceptions import ExternalServiceError
-from app.domain.services.coordinate_service import calculate_distance
-from app.domain.services.landmark_service import (
-    calculate_search_radius,
-    generate_equidistant_circle_points,
-)
 from app.domain.value_objects import Coordinate, Landmark
 
 logger = logging.getLogger(__name__)
@@ -26,15 +19,15 @@ logger = logging.getLogger(__name__)
 class LandmarkSearchService:
     """ランドマーク検索サービス
 
-    段階的探索戦略を用いてランドマークを検索します。
+    Apple Maps のクエリバッグ検索で、目標距離帯上のランドマークを集めます。
     """
 
     @inject
-    def __init__(self, gateway: GoogleMapsGateway) -> None:
+    def __init__(self, gateway: AppleMapsGateway) -> None:
         """初期化
 
         Args:
-            gateway: GoogleMapsGatewayのインスタンス
+            gateway: AppleMapsGateway のインスタンス
         """
         self._gateway = gateway
 
@@ -47,123 +40,42 @@ class LandmarkSearchService:
     ) -> list[Landmark]:
         """ランドマーク検索
 
-        Nearby APIでは注目度順で最大20件までしか取得できないため、段階的に取得する
-
-        1. まずは中心地から指定した距離内のランドマークを20件検索
-        2. 円周上に等間隔の点を生成し、それぞれの点から指定した距離内のランドマークを20件検索
-        3. 2つの検索結果を結合して、目標件数に達するまで繰り返す
+        Apple /v1/search で層別日本語クエリ → 不足時円周ファンアウトを行い、
+        目標距離 ±tolerance% 帯のユニーク件数を集める。
 
         Args:
             center: 中心座標
-            target_distance_m: 指定距離 (メートル)。検索半径および距離フィルタリングに使用。
-                ±LANDMARK_DISTANCE_TOLERANCE_PERCENT%の範囲でフィルタリング
+            target_distance_m: 指定距離 (メートル)。距離帯フィルタリングに使用。
             target_count: 目標件数
-            max_calls: 最大API呼び出し回数
+            max_calls: 最大 API 呼び出し回数
 
         Returns:
             ランドマークのリスト (重複排除済み、距離フィルタリング適用済み)
         """
-        # 距離フィルタリング用の範囲計算:
-        # target_distance_m * (1 - tolerance) <= distance <= target_distance_m * (1 + tolerance)
-        tolerance = LANDMARK_DISTANCE_TOLERANCE_PERCENT / 100.0
-        min_filter_distance = target_distance_m * (1 - tolerance)
-        max_filter_distance = target_distance_m * (1 + tolerance)
-
-        seen: dict[str, Landmark] = {}  # Place IDをキーとした重複排除用マップ
-        calls = 0
-
-        # 1. 中心地から指定した距離内のランドマークを検索
-        logger.debug(f"Search landmarks around center: {center}")
+        logger.debug(
+            "Search landmarks via Apple Maps: center=%s distance=%s target=%s max_calls=%s",
+            center,
+            target_distance_m,
+            target_count,
+            max_calls,
+        )
         try:
-            landmarks = self._gateway.search_landmarks_nearby(center, target_distance_m)
-            calls += 1
-            seen = self._add_landmarks(
-                seen, landmarks, min_filter_distance, max_filter_distance, center
+            hits = self._gateway.search_landmarks_nearby(
+                center,
+                target_distance_m,
+                target_count=target_count,
+                max_calls=max_calls,
             )
-            logger.debug(f"Find {len(seen)} new landmarks around center")
-            if self._should_stop(seen, target_count, calls, max_calls):
-                return list(seen.values())
         except ExternalServiceError:
             logger.warning(
-                f"中心点 ({center.latitude:.4f}, {center.longitude:.4f}) でのランドマーク検索失敗",
+                "ランドマーク検索失敗: center=(%.4f, %.4f) distance=%s",
+                float(center.latitude),
+                float(center.longitude),
+                target_distance_m,
                 exc_info=True,
             )
             return []
 
-        # 2. 円周上に等間隔の点を生成し、それぞれの点から指定した距離内のランドマークを検索
-        search_radius = calculate_search_radius(target_distance_m, tolerance, MIN_SEARCH_RADIUS_M)
-        circle_points = generate_equidistant_circle_points(center, target_distance_m, search_radius)
-
-        # 円周上の点から指定した距離内のランドマークを検索
-        logger.debug(f"Search landmarks around circle points: {circle_points}")
-        for point_lat, point_lng in circle_points:
-            try:
-                point_coordinate = Coordinate(latitude=point_lat, longitude=point_lng)
-                landmarks = self._gateway.search_landmarks_nearby(point_coordinate, search_radius)
-                calls += 1
-                prev_seen_length = len(seen)
-                seen = self._add_landmarks(
-                    seen, landmarks, min_filter_distance, max_filter_distance, center
-                )
-                logger.debug(
-                    f"Find {len(seen) - prev_seen_length} new landmarks around circle points"
-                )
-                if self._should_stop(seen, target_count, calls, max_calls):
-                    return list(seen.values())
-            except ExternalServiceError as e:
-                # 個別の点でのエラーは無視して続行
-                logger.warning(
-                    f"円周上の点 ({point_lat:.4f}, {point_lng:.4f}) で検索失敗: {e}",
-                    exc_info=True,
-                )
-                continue
-
-        return list(seen.values())
-
-    def _add_landmarks(
-        self,
-        seen: dict[str, Landmark],
-        landmarks: list[Landmark],
-        min_filter_distance: float,
-        max_filter_distance: float,
-        center: Coordinate,
-    ) -> dict[str, Landmark]:
-        """距離フィルタリング付きで結果を追加"""
-        # 非破壊的メソッドにするためにcopyを使用
-        new_seen: dict[str, Landmark] = seen.copy()
-
-        for landmark in landmarks:
-            place_id = landmark.place_id
-            if place_id in new_seen:
-                continue
-
-            # 距離フィルタリング
-            dist = calculate_distance(center, landmark.coordinate)
-            if min_filter_distance <= dist <= max_filter_distance:
-                new_seen[place_id] = landmark
-
-        return new_seen
-
-    def _should_stop(
-        self,
-        seen: dict[str, Landmark],
-        target_count: int,
-        calls: int,
-        max_calls: int,
-    ) -> bool:
-        """停止条件をチェック
-
-        目標件数に達したか、最大呼び出し回数に達したか
-
-        Args:
-            seen: 発見済みランドマークのマップ
-            target_count: 目標件数
-            calls: 呼び出し回数
-            max_calls: 最大呼び出し回数
-
-        Returns:
-            停止条件を満たしているかどうか
-        """
-        reached_target_count = len(seen) >= target_count
-        reached_max_calls = calls >= max_calls
-        return reached_target_count or reached_max_calls
+        landmarks = [hit.to_landmark() for hit in hits]
+        logger.debug("Find %s landmarks via Apple Maps", len(landmarks))
+        return landmarks

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -100,5 +100,12 @@ if not GOOGLE_API_KEY:
         "GOOGLE_API_KEY環境変数が設定されていません。.envファイルまたは環境変数に設定してください。"
     )
 
+# Apple Maps Server API (検索スパイク / probe 用。未設定でもアプリ起動・単体テストは通す)
+# Maps ID (APPLE_MAPS_ID) は Developer で鍵を作るときに紐づける識別子で、JWT claims には含めない。
+APPLE_TEAM_ID = os.environ.get("APPLE_TEAM_ID")
+APPLE_MAPS_KEY_ID = os.environ.get("APPLE_MAPS_KEY_ID")
+APPLE_MAPS_PRIVATE_KEY_PATH = os.environ.get("APPLE_MAPS_PRIVATE_KEY_PATH")
+APPLE_MAPS_ID = os.environ.get("APPLE_MAPS_ID")
+
 # 環境 (dev または prod) を取得
 ENV = os.environ.get("ENV", "dev")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -100,10 +100,13 @@ if not GOOGLE_API_KEY:
         "GOOGLE_API_KEY環境変数が設定されていません。.envファイルまたは環境変数に設定してください。"
     )
 
-# Apple Maps Server API (検索スパイク / probe 用。未設定でもアプリ起動・単体テストは通す)
+# Apple Maps Server API (目的地ランドマーク検索用。未設定でもアプリ起動・単体テストは通す)
 # Maps ID (APPLE_MAPS_ID) は Developer で鍵を作るときに紐づける識別子で、JWT claims には含めない。
 APPLE_TEAM_ID = os.environ.get("APPLE_TEAM_ID")
 APPLE_MAPS_KEY_ID = os.environ.get("APPLE_MAPS_KEY_ID")
+# Cloud Run: Secret Manager → APPLE_MAPS_PRIVATE_KEY (PEM 文字列) を優先
+APPLE_MAPS_PRIVATE_KEY = os.environ.get("APPLE_MAPS_PRIVATE_KEY")
+# ローカル: .p8 ファイルパス (APPLE_MAPS_PRIVATE_KEY が無いときのフォールバック)
 APPLE_MAPS_PRIVATE_KEY_PATH = os.environ.get("APPLE_MAPS_PRIVATE_KEY_PATH")
 APPLE_MAPS_ID = os.environ.get("APPLE_MAPS_ID")
 

--- a/backend/app/container.py
+++ b/backend/app/container.py
@@ -6,7 +6,9 @@ Infrastructure層の実装への依存は、この設定モジュールに集約
 
 from injector import Injector
 
+from app.application.gateway_interfaces.apple_maps_gateway import AppleMapsGateway
 from app.application.gateway_interfaces.google_maps_gateway import GoogleMapsGateway
+from app.infrastructure.gateways.apple_maps_gateway_impl import AppleMapsGatewayImpl
 from app.infrastructure.gateways.google_maps_gateway_impl import GoogleMapsGatewayImpl
 
 
@@ -18,6 +20,8 @@ def create_container() -> Injector:
     """
     injector = Injector()
     injector.binder.bind(GoogleMapsGateway, to=GoogleMapsGatewayImpl)
+    # 目的地ランドマーク検索のみ Apple。Directions / Street View / Roads / 中間地点は Google。
+    injector.binder.bind(AppleMapsGateway, to=AppleMapsGatewayImpl)
     return injector
 
 

--- a/backend/app/domain/services/landmark_service.py
+++ b/backend/app/domain/services/landmark_service.py
@@ -33,6 +33,8 @@ def generate_equidistant_circle_points(
     center: Coordinate,
     target_distance: int,
     search_radius: float,
+    *,
+    seed: int | None = None,
 ) -> list[tuple[float, float]]:
     """指定距離の円周上に等間隔で点を生成 (全周に散らす順番)
 
@@ -40,6 +42,7 @@ def generate_equidistant_circle_points(
         center: 中心座標
         target_distance: 指定距離 (メートル)
         search_radius: 各点での検索半径 (メートル)
+        seed: 指定時は散らし順を再現可能にする
 
     Returns:
         円周上の点のリスト [(lat, lng), ...] (全周に散らす順番)
@@ -55,8 +58,8 @@ def generate_equidistant_circle_points(
     # 全周に散らす順番のインデックスを生成
     # 例: 8点の場合 → [0, 4, 2, 6, 1, 5, 3, 7]
     # これにより、最初の数回で全周をカバーできる
-    # 開始位置はランダムにオフセットされる
-    scattered_indices = _generate_scattered_indices(num_points)
+    # 開始位置はランダムにオフセットされる (seed 指定時は再現可能)
+    scattered_indices = _generate_scattered_indices(num_points, seed=seed)
 
     points: list[tuple[float, float]] = []
     origin = (center.latitude, center.longitude)
@@ -73,14 +76,15 @@ def generate_equidistant_circle_points(
     return points
 
 
-def _generate_scattered_indices(n: int) -> list[int]:
-    """全周に散らす順番のインデックスを生成 (開始位置はランダム)
+def _generate_scattered_indices(n: int, *, seed: int | None = None) -> list[int]:
+    """全周に散らす順番のインデックスを生成 (開始位置はランダム / seed 可)
 
     n と互いに素な step を使った full-cycle generation により、
     全てのインデックス 0..n-1 を正確に1回ずつ生成します。
 
     Args:
         n: 生成するインデックスの総数
+        seed: 指定時は再現可能な乱数系列を使う
 
     Returns:
         0..n-1 のインデックスを全周に散らした順番で返すリスト
@@ -88,13 +92,16 @@ def _generate_scattered_indices(n: int) -> list[int]:
     if n <= 1:
         return [0]
 
+    # 開始位置・step は暗号用途ではないので random.Random で十分
+    rng = random.Random(seed) if seed is not None else random.Random()  # noqa: S311
+
     # ランダムな開始オフセットを選択
-    offset = random.randrange(n)  # noqa: S311 (ただのランダムの選択なので問題なし)
+    offset = rng.randrange(n)
 
     # n と互いに素な step を 1..n-1 からランダムに選択
     # gcd(step, n) == 1 なら step は n と互いに素
     while True:
-        step = random.randrange(1, n)  # noqa: S311 (ただのランダムの選択なので問題なし)
+        step = rng.randrange(1, n)
         if math.gcd(step, n) == 1:
             break
 

--- a/backend/app/infrastructure/gateways/__init__.py
+++ b/backend/app/infrastructure/gateways/__init__.py
@@ -3,6 +3,7 @@
 外部サービスへのGateway実装を定義します。
 """
 
+from app.infrastructure.gateways.apple_maps_gateway_impl import AppleMapsGatewayImpl
 from app.infrastructure.gateways.google_maps_gateway_impl import GoogleMapsGatewayImpl
 
-__all__ = ["GoogleMapsGatewayImpl"]
+__all__ = ["AppleMapsGatewayImpl", "GoogleMapsGatewayImpl"]

--- a/backend/app/infrastructure/gateways/apple_maps_auth.py
+++ b/backend/app/infrastructure/gateways/apple_maps_auth.py
@@ -234,8 +234,9 @@ class AppleMapsTokenProvider:
 
         access_token = data.get("accessToken")
         if not access_token or not isinstance(access_token, str):
+            keys = sorted(data.keys()) if isinstance(data, dict) else []
             raise ExternalServiceError(
-                "Apple Maps /v1/token response missing accessToken",
+                f"Apple Maps /v1/token response missing accessToken (keys={keys})",
                 service_name=SERVICE_NAME,
             )
 

--- a/backend/app/infrastructure/gateways/apple_maps_auth.py
+++ b/backend/app/infrastructure/gateways/apple_maps_auth.py
@@ -1,0 +1,216 @@
+"""Apple Maps Server API の JWT / access token 管理
+
+認証フロー:
+1. Team ID + Key ID + .p8 で ES256 JWT (maps_auth_token) を署名
+2. GET /v1/token で短い access token に交換
+3. 有効期限までキャッシュして再利用
+
+参考:
+https://developer.apple.com/documentation/applemapsserverapi/creating-and-using-tokens-with-maps-server-api
+https://developer.apple.com/documentation/applemapsserverapi/-v1-token
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import cast
+
+import jwt
+import requests
+from requests.exceptions import RequestException, Timeout
+
+from app.config import REQUEST_TIMEOUT_SECONDS
+from app.domain.exceptions import ExternalServiceError, ExternalServiceTimeoutError
+
+logger = logging.getLogger(__name__)
+
+APPLE_MAPS_BASE_URL = "https://maps-api.apple.com/v1"
+# maps_auth_token (自前署名 JWT) の寿命。access token は別途 expiresInSeconds で管理する。
+MAPS_AUTH_TOKEN_TTL_SECONDS = 3600
+# access token 更新の安全マージン (秒)
+ACCESS_TOKEN_EXPIRY_SKEW_SECONDS = 60
+SERVICE_NAME = "Apple Maps Server API"
+
+
+class AppleMapsCredentialsError(ValueError):
+    """Apple Maps 認証に必要な環境変数 / 秘密鍵が不足している"""
+
+
+class AppleMapsTokenProvider:
+    """Maps Server API 用 access token の発行とキャッシュ"""
+
+    def __init__(
+        self,
+        team_id: str,
+        key_id: str,
+        private_key_pem: str,
+        *,
+        base_url: str = APPLE_MAPS_BASE_URL,
+        session: requests.Session | None = None,
+    ) -> None:
+        """初期化
+
+        Args:
+            team_id: Apple Developer Team ID (10 文字)
+            key_id: Maps 用秘密鍵の Key ID (10 文字)
+            private_key_pem: .p8 秘密鍵の PEM 文字列
+            base_url: API ベース URL (テスト差し替え用)
+            session: requests.Session (テスト差し替え用)
+        """
+        self._team_id = team_id
+        self._key_id = key_id
+        self._private_key_pem = private_key_pem
+        self._base_url = base_url.rstrip("/")
+        self._session = session or requests.Session()
+        self._access_token: str | None = None
+        self._access_token_expires_at: float = 0.0
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        team_id: str | None,
+        key_id: str | None,
+        private_key_path: str | None,
+        backend_dir: Path | None = None,
+        base_url: str = APPLE_MAPS_BASE_URL,
+        session: requests.Session | None = None,
+    ) -> AppleMapsTokenProvider:
+        """環境変数相当の値から Provider を構築する。
+
+        Args:
+            team_id: APPLE_TEAM_ID
+            key_id: APPLE_MAPS_KEY_ID
+            private_key_path: APPLE_MAPS_PRIVATE_KEY_PATH (.p8 パス)
+            backend_dir: 相対パス解決の基準 (未指定なら CWD)
+            base_url: API ベース URL
+            session: requests.Session
+
+        Returns:
+            AppleMapsTokenProvider
+
+        Raises:
+            AppleMapsCredentialsError: 必須値が欠けている / 鍵ファイルが読めない場合
+        """
+        missing = [
+            name
+            for name, value in (
+                ("APPLE_TEAM_ID", team_id),
+                ("APPLE_MAPS_KEY_ID", key_id),
+                ("APPLE_MAPS_PRIVATE_KEY_PATH", private_key_path),
+            )
+            if not (value and value.strip())
+        ]
+        if missing:
+            raise AppleMapsCredentialsError(
+                "Apple Maps Server API の認証情報が不足しています: "
+                + ", ".join(missing)
+                + "。backend/.env.example を参照して設定してください。"
+            )
+
+        resolved_team_id = cast(str, team_id).strip()
+        resolved_key_id = cast(str, key_id).strip()
+        resolved_key_path = cast(str, private_key_path).strip()
+
+        key_path = Path(resolved_key_path).expanduser()
+        if not key_path.is_absolute():
+            root = backend_dir if backend_dir is not None else Path.cwd()
+            key_path = root / key_path
+        if not key_path.is_file():
+            raise AppleMapsCredentialsError(f"秘密鍵ファイルが見つかりません: {key_path}")
+
+        private_key_pem = key_path.read_text(encoding="utf-8")
+        return cls(
+            team_id=resolved_team_id,
+            key_id=resolved_key_id,
+            private_key_pem=private_key_pem,
+            base_url=base_url,
+            session=session,
+        )
+
+    def create_maps_auth_token(self, *, now: float | None = None) -> str:
+        """ES256 で maps_auth_token (JWT) を署名する。
+
+        Args:
+            now: 現在時刻 (UNIX 秒)。テスト差し替え用。
+
+        Returns:
+            str: 署名済み JWT
+        """
+        issued_at = int(time.time() if now is None else now)
+        headers = {
+            "alg": "ES256",
+            "kid": self._key_id,
+            "typ": "JWT",
+        }
+        payload = {
+            "iss": self._team_id,
+            "iat": issued_at,
+            "exp": issued_at + MAPS_AUTH_TOKEN_TTL_SECONDS,
+            "scope": "server_api",
+        }
+        return jwt.encode(payload, self._private_key_pem, algorithm="ES256", headers=headers)
+
+    def get_access_token(self, *, force_refresh: bool = False, now: float | None = None) -> str:
+        """有効な access token を返す (期限までキャッシュ)。
+
+        Args:
+            force_refresh: True ならキャッシュを無視して再取得
+            now: 現在時刻 (UNIX 秒)。テスト差し替え用。
+
+        Returns:
+            str: Bearer に載せる access token
+
+        Raises:
+            ExternalServiceError: /v1/token 呼び出し失敗
+            ExternalServiceTimeoutError: タイムアウト
+        """
+        current = time.time() if now is None else now
+        if (
+            not force_refresh
+            and self._access_token is not None
+            and current < self._access_token_expires_at - ACCESS_TOKEN_EXPIRY_SKEW_SECONDS
+        ):
+            return self._access_token
+
+        maps_auth_token = self.create_maps_auth_token(now=current)
+        url = f"{self._base_url}/token"
+        try:
+            response = self._session.get(
+                url,
+                headers={"Authorization": f"Bearer {maps_auth_token}"},
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except Timeout as error:
+            logger.error("Timeout while exchanging Apple Maps access token.")
+            raise ExternalServiceTimeoutError(
+                "Request timeout: Failed to exchange Apple Maps access token",
+                service_name=SERVICE_NAME,
+            ) from error
+        except RequestException as error:
+            logger.error("Failed to exchange Apple Maps access token: %s", error)
+            raise ExternalServiceError(
+                f"Failed to exchange Apple Maps access token: {error}",
+                service_name=SERVICE_NAME,
+            ) from error
+
+        access_token = data.get("accessToken")
+        if not access_token or not isinstance(access_token, str):
+            raise ExternalServiceError(
+                f"Apple Maps /v1/token response missing accessToken: {data}",
+                service_name=SERVICE_NAME,
+            )
+
+        expires_in = data.get("expiresInSeconds", 1800)
+        try:
+            expires_in_seconds = float(expires_in)
+        except (TypeError, ValueError):
+            expires_in_seconds = 1800.0
+
+        self._access_token = access_token
+        self._access_token_expires_at = current + expires_in_seconds
+        return access_token

--- a/backend/app/infrastructure/gateways/apple_maps_auth.py
+++ b/backend/app/infrastructure/gateways/apple_maps_auth.py
@@ -1,9 +1,13 @@
 """Apple Maps Server API の JWT / access token 管理
 
 認証フロー:
-1. Team ID + Key ID + .p8 で ES256 JWT (maps_auth_token) を署名
+1. Team ID + Key ID + .p8/PEM で ES256 JWT (maps_auth_token) を署名
 2. GET /v1/token で短い access token に交換
 3. 有効期限までキャッシュして再利用
+
+秘密鍵は Cloud Run では APPLE_MAPS_PRIVATE_KEY (PEM 文字列)、
+ローカルでは APPLE_MAPS_PRIVATE_KEY_PATH (.p8 ファイル) を優先順で読む。
+PEM / token はログに出さない。
 
 参考:
 https://developer.apple.com/documentation/applemapsserverapi/creating-and-using-tokens-with-maps-server-api
@@ -68,21 +72,43 @@ class AppleMapsTokenProvider:
         self._access_token_expires_at: float = 0.0
 
     @classmethod
+    def from_config(cls) -> AppleMapsTokenProvider:
+        """app.config の環境変数から Provider を構築する。"""
+        from app.config import (
+            APPLE_MAPS_KEY_ID,
+            APPLE_MAPS_PRIVATE_KEY,
+            APPLE_MAPS_PRIVATE_KEY_PATH,
+            APPLE_TEAM_ID,
+        )
+
+        return cls.from_env(
+            team_id=APPLE_TEAM_ID,
+            key_id=APPLE_MAPS_KEY_ID,
+            private_key_pem=APPLE_MAPS_PRIVATE_KEY,
+            private_key_path=APPLE_MAPS_PRIVATE_KEY_PATH,
+        )
+
+    @classmethod
     def from_env(
         cls,
         *,
         team_id: str | None,
         key_id: str | None,
-        private_key_path: str | None,
+        private_key_pem: str | None = None,
+        private_key_path: str | None = None,
         backend_dir: Path | None = None,
         base_url: str = APPLE_MAPS_BASE_URL,
         session: requests.Session | None = None,
     ) -> AppleMapsTokenProvider:
         """環境変数相当の値から Provider を構築する。
 
+        秘密鍵は APPLE_MAPS_PRIVATE_KEY (PEM) を優先し、無ければ
+        APPLE_MAPS_PRIVATE_KEY_PATH (.p8) を読む。
+
         Args:
             team_id: APPLE_TEAM_ID
             key_id: APPLE_MAPS_KEY_ID
+            private_key_pem: APPLE_MAPS_PRIVATE_KEY (PEM 文字列)
             private_key_path: APPLE_MAPS_PRIVATE_KEY_PATH (.p8 パス)
             backend_dir: 相対パス解決の基準 (未指定なら CWD)
             base_url: API ベース URL
@@ -92,40 +118,48 @@ class AppleMapsTokenProvider:
             AppleMapsTokenProvider
 
         Raises:
-            AppleMapsCredentialsError: 必須値が欠けている / 鍵ファイルが読めない場合
+            AppleMapsCredentialsError: 必須値が欠けている / 鍵が読めない場合
         """
-        missing = [
+        missing_ids = [
             name
             for name, value in (
                 ("APPLE_TEAM_ID", team_id),
                 ("APPLE_MAPS_KEY_ID", key_id),
-                ("APPLE_MAPS_PRIVATE_KEY_PATH", private_key_path),
             )
             if not (value and value.strip())
         ]
-        if missing:
+        if missing_ids:
             raise AppleMapsCredentialsError(
                 "Apple Maps Server API の認証情報が不足しています: "
-                + ", ".join(missing)
+                + ", ".join(missing_ids)
                 + "。backend/.env.example を参照して設定してください。"
             )
 
-        resolved_team_id = cast(str, team_id).strip()
-        resolved_key_id = cast(str, key_id).strip()
-        resolved_key_path = cast(str, private_key_path).strip()
+        pem = (private_key_pem or "").strip()
+        if not pem:
+            path_value = (private_key_path or "").strip()
+            if not path_value:
+                raise AppleMapsCredentialsError(
+                    "Apple Maps Server API の秘密鍵が不足しています: "
+                    "APPLE_MAPS_PRIVATE_KEY または APPLE_MAPS_PRIVATE_KEY_PATH を設定してください。"
+                )
+            key_path = Path(path_value).expanduser()
+            if not key_path.is_absolute():
+                root = backend_dir if backend_dir is not None else Path.cwd()
+                key_path = root / key_path
+            if not key_path.is_file():
+                raise AppleMapsCredentialsError(f"秘密鍵ファイルが見つかりません: {key_path}")
+            pem = key_path.read_text(encoding="utf-8").strip()
 
-        key_path = Path(resolved_key_path).expanduser()
-        if not key_path.is_absolute():
-            root = backend_dir if backend_dir is not None else Path.cwd()
-            key_path = root / key_path
-        if not key_path.is_file():
-            raise AppleMapsCredentialsError(f"秘密鍵ファイルが見つかりません: {key_path}")
+        if "PRIVATE KEY" not in pem:
+            raise AppleMapsCredentialsError(
+                "APPLE_MAPS_PRIVATE_KEY / 鍵ファイルの内容が PEM 形式ではありません。"
+            )
 
-        private_key_pem = key_path.read_text(encoding="utf-8")
         return cls(
-            team_id=resolved_team_id,
-            key_id=resolved_key_id,
-            private_key_pem=private_key_pem,
+            team_id=cast(str, team_id).strip(),
+            key_id=cast(str, key_id).strip(),
+            private_key_pem=pem,
             base_url=base_url,
             session=session,
         )
@@ -201,7 +235,7 @@ class AppleMapsTokenProvider:
         access_token = data.get("accessToken")
         if not access_token or not isinstance(access_token, str):
             raise ExternalServiceError(
-                f"Apple Maps /v1/token response missing accessToken: {data}",
+                "Apple Maps /v1/token response missing accessToken",
                 service_name=SERVICE_NAME,
             )
 

--- a/backend/app/infrastructure/gateways/apple_maps_gateway_impl.py
+++ b/backend/app/infrastructure/gateways/apple_maps_gateway_impl.py
@@ -1,0 +1,364 @@
+"""Apple Maps Server API 検索 Gateway 実装 (スパイク)
+
+GoogleMapsGateway を差し替えず、カテゴリ検索 + 日本語クエリバッグの品質検証専用。
+
+- 円近傍: center+radius → searchRegion bbox に近似し、自前で距離帯フィルタ
+- カテゴリ検索: includePoiCategories (q は省略を試し、400 なら汎用 q にフォールバック)
+- 件数不足時: 公園/神社/カフェ/... のクエリバッグを同一 bbox で再検索
+- place_id は `apple:<id>` で Google place_id と衝突しないようにする
+
+参考: https://developer.apple.com/documentation/applemapsserverapi/-v1-search
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import requests
+from requests.exceptions import HTTPError, RequestException, Timeout
+
+from app.application.gateway_interfaces.apple_maps_gateway import (
+    AppleMapsGateway,
+    AppleSearchHit,
+    AppleSearchSource,
+)
+from app.config import (
+    LANDMARK_DISTANCE_TOLERANCE_PERCENT,
+    LANDMARK_SEARCH_TARGET_COUNT,
+    REQUEST_TIMEOUT_SECONDS,
+)
+from app.domain.exceptions import ExternalServiceError, ExternalServiceTimeoutError
+from app.domain.services.coordinate_service import calculate_distance
+from app.domain.value_objects import Coordinate
+from app.infrastructure.gateways.apple_maps_auth import (
+    APPLE_MAPS_BASE_URL,
+    AppleMapsTokenProvider,
+)
+from app.infrastructure.gateways.apple_poi_category_mapping import (
+    map_google_types_to_apple_poi_categories,
+)
+
+logger = logging.getLogger(__name__)
+
+SERVICE_NAME = "Apple Maps Server API"
+PLACE_ID_PREFIX = "apple:"
+
+# 1 度の緯度あたりのおよそのメートル (bbox 近似用)
+_METERS_PER_DEGREE_LAT = 111_320.0
+
+# カテゴリ検索で `q` 省略が 400 になった場合の汎用クエリ。
+# コミュニティ SDK は q を required と記載。omit / empty / 汎用の可否は probe で確認する。
+CATEGORY_SEARCH_GENERIC_Q = "スポット"
+
+# カテゴリ検索でヒットが少ないときの日本語クエリバッグ
+FALLBACK_QUERY_BAG: tuple[str, ...] = (
+    "公園",
+    "神社",
+    "カフェ",
+    "博物館",
+    "城",
+    "展望台",
+)
+
+SearchRegion = tuple[float, float, float, float]  # north, east, south, west
+
+
+def circle_to_search_region(center: Coordinate, radius_m: float) -> SearchRegion:
+    """中心 + 半径 (m) を Apple searchRegion (north,east,south,west) に近似する。
+
+    Args:
+        center: 円の中心
+        radius_m: 半径 (メートル)
+
+    Returns:
+        SearchRegion: (north, east, south, west)
+    """
+    lat = float(center.latitude)
+    lng = float(center.longitude)
+    delta_lat = radius_m / _METERS_PER_DEGREE_LAT
+    cos_lat = math.cos(math.radians(lat))
+    # 極付近で cos≈0 になるのを防ぐ
+    meters_per_degree_lng = _METERS_PER_DEGREE_LAT * max(abs(cos_lat), 1e-6)
+    delta_lng = radius_m / meters_per_degree_lng
+
+    north = min(90.0, lat + delta_lat)
+    south = max(-90.0, lat - delta_lat)
+    east = lng + delta_lng
+    west = lng - delta_lng
+    if east > 180.0:
+        east = 180.0
+    if west < -180.0:
+        west = -180.0
+    return (north, east, south, west)
+
+
+def format_search_region(region: SearchRegion) -> str:
+    """searchRegion クエリ文字列 (north,east,south,west) を作る。"""
+    north, east, south, west = region
+    return f"{north},{east},{south},{west}"
+
+
+def distance_band_bounds(
+    target_distance_m: float,
+    tolerance_percent: float,
+) -> tuple[float, float]:
+    """目標距離に対する ±tolerance% の下限・上限 (m) を返す。"""
+    ratio = tolerance_percent / 100.0
+    return target_distance_m * (1.0 - ratio), target_distance_m * (1.0 + ratio)
+
+
+def prefix_apple_place_id(raw_id: str) -> str:
+    """Apple place id に衝突回避プレフィックスを付ける。"""
+    if raw_id.startswith(PLACE_ID_PREFIX):
+        return raw_id
+    return f"{PLACE_ID_PREFIX}{raw_id}"
+
+
+class AppleMapsGatewayImpl(AppleMapsGateway):
+    """Apple Maps Server API 検索の実装 (本番 DI には未接続)"""
+
+    def __init__(
+        self,
+        token_provider: AppleMapsTokenProvider,
+        *,
+        base_url: str = APPLE_MAPS_BASE_URL,
+        session: requests.Session | None = None,
+        fallback_queries: tuple[str, ...] = FALLBACK_QUERY_BAG,
+        category_generic_q: str = CATEGORY_SEARCH_GENERIC_Q,
+    ) -> None:
+        """初期化
+
+        Args:
+            token_provider: access token 供給
+            base_url: API ベース URL
+            session: requests.Session
+            fallback_queries: 件数不足時のクエリバッグ
+            category_generic_q: カテゴリ検索で q 省略が拒否されたときの汎用 q
+        """
+        self._token_provider = token_provider
+        self._base_url = base_url.rstrip("/")
+        self._session = session or requests.Session()
+        self._fallback_queries = fallback_queries
+        self._category_generic_q = category_generic_q
+
+    def search_landmarks_nearby(
+        self,
+        coordinate: Coordinate,
+        radius_m: int,
+        *,
+        target_count: int | None = None,
+        distance_tolerance_percent: float | None = None,
+    ) -> list[AppleSearchHit]:
+        """カテゴリ検索 → 不足時クエリバッグで距離帯内 POI を返す。"""
+        if radius_m <= 0:
+            raise ValueError("radius_m must be positive")
+
+        resolved_target = LANDMARK_SEARCH_TARGET_COUNT if target_count is None else target_count
+        resolved_tolerance = (
+            LANDMARK_DISTANCE_TOLERANCE_PERCENT
+            if distance_tolerance_percent is None
+            else distance_tolerance_percent
+        )
+        min_distance_m, max_distance_m = distance_band_bounds(float(radius_m), resolved_tolerance)
+        # bbox は距離帯の外側まで覆う
+        region = circle_to_search_region(coordinate, max_distance_m)
+        categories = map_google_types_to_apple_poi_categories()
+
+        hits_by_id: dict[str, AppleSearchHit] = {}
+
+        category_results = self._search_by_categories(
+            center=coordinate,
+            region=region,
+            categories=categories,
+        )
+        self._merge_in_band_hits(
+            hits_by_id=hits_by_id,
+            raw_results=category_results,
+            center=coordinate,
+            min_distance_m=min_distance_m,
+            max_distance_m=max_distance_m,
+            source="category",
+        )
+
+        if len(hits_by_id) < resolved_target:
+            for query in self._fallback_queries:
+                if len(hits_by_id) >= resolved_target:
+                    break
+                query_results = self._search_by_query(
+                    center=coordinate,
+                    region=region,
+                    query=query,
+                )
+                self._merge_in_band_hits(
+                    hits_by_id=hits_by_id,
+                    raw_results=query_results,
+                    center=coordinate,
+                    min_distance_m=min_distance_m,
+                    max_distance_m=max_distance_m,
+                    source="query",
+                )
+
+        return list(hits_by_id.values())
+
+    def _search_by_categories(
+        self,
+        *,
+        center: Coordinate,
+        region: SearchRegion,
+        categories: list[str],
+    ) -> list[dict[str, Any]]:
+        """includePoiCategories でカテゴリ検索する。
+
+        q の扱い (スパイク時点の方針):
+        1. まず q を付けずにカテゴリのみで呼ぶ (category-only 仮説)
+        2. HTTP 400 なら汎用 q (CATEGORY_SEARCH_GENERIC_Q) を付けて再試行
+        空文字 q は送らない (Apple が拒否しうるパラメータを増やさない)。
+        """
+        params = self._base_search_params(center=center, region=region)
+        params["includePoiCategories"] = ",".join(categories)
+
+        try:
+            return self._get_search_results(params)
+        except ExternalServiceError as error:
+            if not self._is_bad_request(error):
+                raise
+            logger.info(
+                "Category search without q was rejected; retrying with generic q=%s",
+                self._category_generic_q,
+            )
+            params_with_q = dict(params)
+            params_with_q["q"] = self._category_generic_q
+            return self._get_search_results(params_with_q)
+
+    def _search_by_query(
+        self,
+        *,
+        center: Coordinate,
+        region: SearchRegion,
+        query: str,
+    ) -> list[dict[str, Any]]:
+        """日本語クエリで同一 bbox を再検索する (フォールバック)。"""
+        params = self._base_search_params(center=center, region=region)
+        params["q"] = query
+        return self._get_search_results(params)
+
+    def _base_search_params(
+        self,
+        *,
+        center: Coordinate,
+        region: SearchRegion,
+    ) -> dict[str, str]:
+        lat, lng = center.to_float_tuple()
+        return {
+            "searchRegion": format_search_region(region),
+            "searchLocation": f"{lat},{lng}",
+            "resultTypeFilter": "Poi",
+            "lang": "ja-JP",
+            "limitToCountries": "JP",
+        }
+
+    def _get_search_results(self, params: dict[str, str]) -> list[dict[str, Any]]:
+        access_token = self._token_provider.get_access_token()
+        url = f"{self._base_url}/search"
+        try:
+            response = self._session.get(
+                url,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params=params,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except Timeout as error:
+            logger.error("Timeout while calling Apple Maps /v1/search")
+            raise ExternalServiceTimeoutError(
+                "Request timeout: Failed to search Apple Maps",
+                service_name=SERVICE_NAME,
+            ) from error
+        except HTTPError as error:
+            status = error.response.status_code if error.response is not None else None
+            body = error.response.text if error.response is not None else ""
+            message = f"Failed to search Apple Maps: HTTP {status} {body}".strip()
+            raise ExternalServiceError(message, service_name=SERVICE_NAME) from error
+        except RequestException as error:
+            logger.error("Request error while calling Apple Maps /v1/search: %s", error)
+            raise ExternalServiceError(
+                f"Failed to search Apple Maps: {error}",
+                service_name=SERVICE_NAME,
+            ) from error
+
+        results = data.get("results", [])
+        if not isinstance(results, list):
+            return []
+        return [item for item in results if isinstance(item, dict)]
+
+    def _merge_in_band_hits(
+        self,
+        *,
+        hits_by_id: dict[str, AppleSearchHit],
+        raw_results: list[dict[str, Any]],
+        center: Coordinate,
+        min_distance_m: float,
+        max_distance_m: float,
+        source: AppleSearchSource,
+    ) -> None:
+        for item in raw_results:
+            hit = self._parse_hit(item, center=center, source=source)
+            if hit is None:
+                continue
+            if hit.distance_m < min_distance_m or hit.distance_m > max_distance_m:
+                continue
+            if hit.place_id in hits_by_id:
+                continue
+            hits_by_id[hit.place_id] = hit
+
+    def _parse_hit(
+        self,
+        item: dict[str, Any],
+        *,
+        center: Coordinate,
+        source: AppleSearchSource,
+    ) -> AppleSearchHit | None:
+        raw_id = item.get("id") or item.get("identifier") or item.get("muid")
+        if raw_id is None:
+            return None
+        place_id = prefix_apple_place_id(str(raw_id))
+
+        name = item.get("name")
+        if not name or not isinstance(name, str):
+            return None
+
+        coordinate_data = item.get("coordinate")
+        if not isinstance(coordinate_data, dict):
+            return None
+        lat_value = coordinate_data.get("latitude")
+        lng_value = coordinate_data.get("longitude")
+        if lat_value is None or lng_value is None:
+            return None
+        try:
+            landmark_coordinate = Coordinate(
+                latitude=float(lat_value),
+                longitude=float(lng_value),
+            )
+        except (TypeError, ValueError):
+            return None
+
+        distance_m = calculate_distance(center, landmark_coordinate)
+        poi_category = item.get("poiCategory")
+        if poi_category is not None and not isinstance(poi_category, str):
+            poi_category = str(poi_category)
+
+        return AppleSearchHit(
+            place_id=place_id,
+            display_name=name,
+            coordinate=landmark_coordinate,
+            distance_m=distance_m,
+            source=source,
+            poi_category=poi_category,
+        )
+
+    @staticmethod
+    def _is_bad_request(error: ExternalServiceError) -> bool:
+        return "HTTP 400" in error.message

--- a/backend/app/infrastructure/gateways/apple_maps_gateway_impl.py
+++ b/backend/app/infrastructure/gateways/apple_maps_gateway_impl.py
@@ -169,7 +169,6 @@ class AppleMapsGatewayImpl(AppleMapsGateway):
         hits_by_id: dict[str, AppleSearchHit] = {}
 
         category_results = self._search_by_categories(
-            center=coordinate,
             region=region,
             categories=categories,
         )
@@ -187,7 +186,6 @@ class AppleMapsGatewayImpl(AppleMapsGateway):
                 if len(hits_by_id) >= resolved_target:
                     break
                 query_results = self._search_by_query(
-                    center=coordinate,
                     region=region,
                     query=query,
                 )
@@ -205,7 +203,6 @@ class AppleMapsGatewayImpl(AppleMapsGateway):
     def _search_by_categories(
         self,
         *,
-        center: Coordinate,
         region: SearchRegion,
         categories: list[str],
     ) -> list[dict[str, Any]]:
@@ -215,8 +212,11 @@ class AppleMapsGatewayImpl(AppleMapsGateway):
         1. まず q を付けずにカテゴリのみで呼ぶ (category-only 仮説)
         2. HTTP 400 なら汎用 q (CATEGORY_SEARCH_GENERIC_Q) を付けて再試行
         空文字 q は送らない (Apple が拒否しうるパラメータを増やさない)。
+
+        地理ヒントは searchRegion のみ送る。
+        Apple は searchRegion と searchLocation の同時指定を 400 で拒否する。
         """
-        params = self._base_search_params(center=center, region=region)
+        params = self._base_search_params(region=region)
         params["includePoiCategories"] = ",".join(categories)
 
         try:
@@ -235,25 +235,18 @@ class AppleMapsGatewayImpl(AppleMapsGateway):
     def _search_by_query(
         self,
         *,
-        center: Coordinate,
         region: SearchRegion,
         query: str,
     ) -> list[dict[str, Any]]:
         """日本語クエリで同一 bbox を再検索する (フォールバック)。"""
-        params = self._base_search_params(center=center, region=region)
+        params = self._base_search_params(region=region)
         params["q"] = query
         return self._get_search_results(params)
 
-    def _base_search_params(
-        self,
-        *,
-        center: Coordinate,
-        region: SearchRegion,
-    ) -> dict[str, str]:
-        lat, lng = center.to_float_tuple()
+    def _base_search_params(self, *, region: SearchRegion) -> dict[str, str]:
+        """共通クエリ。円近傍近似は searchRegion (bbox) のみ (searchLocation は送らない)。"""
         return {
             "searchRegion": format_search_region(region),
-            "searchLocation": f"{lat},{lng}",
             "resultTypeFilter": "Poi",
             "lang": "ja-JP",
             "limitToCountries": "JP",

--- a/backend/app/infrastructure/gateways/apple_maps_gateway_impl.py
+++ b/backend/app/infrastructure/gateways/apple_maps_gateway_impl.py
@@ -1,19 +1,24 @@
-"""Apple Maps Server API 検索 Gateway 実装 (スパイク)
+"""Apple Maps Server API 検索 Gateway 実装
 
-GoogleMapsGateway を差し替えず、カテゴリ検索 + 日本語クエリバッグの品質検証専用。
+本番の目的地ランドマーク検索用。Directions / Street View / Roads は Google のまま。
 
-- 円近傍: center+radius → searchRegion bbox に近似し、自前で距離帯フィルタ
-- カテゴリ検索: includePoiCategories (q は省略を試し、400 なら汎用 q にフォールバック)
-- 件数不足時: 公園/神社/カフェ/... のクエリバッグを同一 bbox で再検索
-- place_id は `apple:<id>` で Google place_id と衝突しないようにする
+検索戦略:
+1. 目標距離 * 1.15 の bbox を searchRegion とし、層別シャッフルした日本語クエリで検索
+   (searchLocation と同時指定しない。カテゴリのみ検索は使わない)
+2. 距離帯 (±tolerance%) 内のユニーク件数で早期停止 (予算は LANDMARK_SEARCH_MAX_CALLS)
+3. 不足時は円周上の点で searchLocation のみのファンアウト (残り予算)
+
+place_id は `apple:<id>` で Google と衝突しない。
 
 参考: https://developer.apple.com/documentation/applemapsserverapi/-v1-search
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import math
+import random
 from typing import Any
 
 import requests
@@ -26,18 +31,21 @@ from app.application.gateway_interfaces.apple_maps_gateway import (
 )
 from app.config import (
     LANDMARK_DISTANCE_TOLERANCE_PERCENT,
+    LANDMARK_SEARCH_MAX_CALLS,
     LANDMARK_SEARCH_TARGET_COUNT,
+    MIN_SEARCH_RADIUS_M,
     REQUEST_TIMEOUT_SECONDS,
 )
 from app.domain.exceptions import ExternalServiceError, ExternalServiceTimeoutError
 from app.domain.services.coordinate_service import calculate_distance
+from app.domain.services.landmark_service import (
+    calculate_search_radius,
+    generate_equidistant_circle_points,
+)
 from app.domain.value_objects import Coordinate
 from app.infrastructure.gateways.apple_maps_auth import (
     APPLE_MAPS_BASE_URL,
     AppleMapsTokenProvider,
-)
-from app.infrastructure.gateways.apple_poi_category_mapping import (
-    map_google_types_to_apple_poi_categories,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,38 +56,33 @@ PLACE_ID_PREFIX = "apple:"
 # 1 度の緯度あたりのおよそのメートル (bbox 近似用)
 _METERS_PER_DEGREE_LAT = 111_320.0
 
-# カテゴリ検索で `q` 省略が 400 になった場合の汎用クエリ。
-# コミュニティ SDK は q を required と記載。omit / empty / 汎用の可否は probe で確認する。
-CATEGORY_SEARCH_GENERIC_Q = "スポット"
+# 高収穫バケット (先頭 3 クエリ用: 各バケットから 1 つ)
+OUTDOOR_QUERY_BUCKET: tuple[str, ...] = ("公園", "展望台")
+CULTURE_QUERY_BUCKET: tuple[str, ...] = ("神社", "寺", "城")
+CASUAL_QUERY_BUCKET: tuple[str, ...] = ("カフェ", "パン", "温泉")
 
-# カテゴリ検索でヒットが少ないときの日本語クエリバッグ
-FALLBACK_QUERY_BAG: tuple[str, ...] = (
-    "公園",
-    "神社",
-    "カフェ",
+# 残りクエリ (バケットの余りと合わせてシャッフル)
+REMAINING_QUERY_BAG: tuple[str, ...] = (
     "博物館",
-    "城",
-    "展望台",
+    "美術館",
+    "銭湯",
+    "道の駅",
+    "灯台",
+    "滝",
+    "湖",
+    "キャンプ",
+    "遊園地",
 )
 
 SearchRegion = tuple[float, float, float, float]  # north, east, south, west
 
 
 def circle_to_search_region(center: Coordinate, radius_m: float) -> SearchRegion:
-    """中心 + 半径 (m) を Apple searchRegion (north,east,south,west) に近似する。
-
-    Args:
-        center: 円の中心
-        radius_m: 半径 (メートル)
-
-    Returns:
-        SearchRegion: (north, east, south, west)
-    """
+    """中心 + 半径 (m) を Apple searchRegion (north,east,south,west) に近似する。"""
     lat = float(center.latitude)
     lng = float(center.longitude)
     delta_lat = radius_m / _METERS_PER_DEGREE_LAT
     cos_lat = math.cos(math.radians(lat))
-    # 極付近で cos≈0 になるのを防ぐ
     meters_per_degree_lng = _METERS_PER_DEGREE_LAT * max(abs(cos_lat), 1e-6)
     delta_lng = radius_m / meters_per_degree_lng
 
@@ -116,32 +119,58 @@ def prefix_apple_place_id(raw_id: str) -> str:
     return f"{PLACE_ID_PREFIX}{raw_id}"
 
 
+def stable_search_seed(center: Coordinate, radius_m: int) -> int:
+    """同一中心・半径で再現可能なシャッフル用シードを作る。"""
+    key = f"{float(center.latitude):.6f}:{float(center.longitude):.6f}:{radius_m}"
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+    return int(digest[:16], 16)
+
+
+def build_stratified_query_bag(seed: int) -> list[str]:
+    """層別シャッフルしたクエリバッグを返す。
+
+    先頭 3 件: outdoor / culture / casual 各バケットをシャッフルした先頭 1 件。
+    以降: バケット余り + REMAINING をシャッフル。
+    """
+    rng = random.Random(seed)  # noqa: S311 — クエリ順の再現用。暗号用途ではない
+    outdoor = list(OUTDOOR_QUERY_BUCKET)
+    culture = list(CULTURE_QUERY_BUCKET)
+    casual = list(CASUAL_QUERY_BUCKET)
+    rng.shuffle(outdoor)
+    rng.shuffle(culture)
+    rng.shuffle(casual)
+
+    first_three = [outdoor[0], culture[0], casual[0]]
+    leftovers = outdoor[1:] + culture[1:] + casual[1:] + list(REMAINING_QUERY_BAG)
+    rng.shuffle(leftovers)
+    return first_three + leftovers
+
+
 class AppleMapsGatewayImpl(AppleMapsGateway):
-    """Apple Maps Server API 検索の実装 (本番 DI には未接続)"""
+    """Apple Maps Server API 検索の実装 (目的地ランドマーク検索向け)"""
 
     def __init__(
         self,
-        token_provider: AppleMapsTokenProvider,
+        token_provider: AppleMapsTokenProvider | None = None,
         *,
         base_url: str = APPLE_MAPS_BASE_URL,
         session: requests.Session | None = None,
-        fallback_queries: tuple[str, ...] = FALLBACK_QUERY_BAG,
-        category_generic_q: str = CATEGORY_SEARCH_GENERIC_Q,
     ) -> None:
         """初期化
 
         Args:
-            token_provider: access token 供給
+            token_provider: access token 供給 (None なら初回アクセス時に from_config)
             base_url: API ベース URL
             session: requests.Session
-            fallback_queries: 件数不足時のクエリバッグ
-            category_generic_q: カテゴリ検索で q 省略が拒否されたときの汎用 q
         """
         self._token_provider = token_provider
         self._base_url = base_url.rstrip("/")
         self._session = session or requests.Session()
-        self._fallback_queries = fallback_queries
-        self._category_generic_q = category_generic_q
+
+    def _provider(self) -> AppleMapsTokenProvider:
+        if self._token_provider is None:
+            self._token_provider = AppleMapsTokenProvider.from_config()
+        return self._token_provider
 
     def search_landmarks_nearby(
         self,
@@ -150,8 +179,9 @@ class AppleMapsGatewayImpl(AppleMapsGateway):
         *,
         target_count: int | None = None,
         distance_tolerance_percent: float | None = None,
+        max_calls: int | None = None,
     ) -> list[AppleSearchHit]:
-        """カテゴリ検索 → 不足時クエリバッグで距離帯内 POI を返す。"""
+        """層別クエリ検索 → 不足時円周ファンアウトで距離帯内 POI を返す。"""
         if radius_m <= 0:
             raise ValueError("radius_m must be positive")
 
@@ -161,99 +191,104 @@ class AppleMapsGatewayImpl(AppleMapsGateway):
             if distance_tolerance_percent is None
             else distance_tolerance_percent
         )
+        resolved_max_calls = LANDMARK_SEARCH_MAX_CALLS if max_calls is None else max_calls
+        if resolved_max_calls <= 0:
+            return []
+
         min_distance_m, max_distance_m = distance_band_bounds(float(radius_m), resolved_tolerance)
-        # bbox は距離帯の外側まで覆う
         region = circle_to_search_region(coordinate, max_distance_m)
-        categories = map_google_types_to_apple_poi_categories()
+        queries = build_stratified_query_bag(stable_search_seed(coordinate, radius_m))
 
         hits_by_id: dict[str, AppleSearchHit] = {}
+        calls = 0
 
-        category_results = self._search_by_categories(
-            region=region,
-            categories=categories,
-        )
-        self._merge_in_band_hits(
-            hits_by_id=hits_by_id,
-            raw_results=category_results,
-            center=coordinate,
-            min_distance_m=min_distance_m,
-            max_distance_m=max_distance_m,
-            source="category",
-        )
+        # 1. クエリフェーズ (searchRegion のみ)
+        for query in queries:
+            if len(hits_by_id) >= resolved_target or calls >= resolved_max_calls:
+                break
+            raw_results = self._search_by_query_region(region=region, query=query)
+            calls += 1
+            self._merge_in_band_hits(
+                hits_by_id=hits_by_id,
+                raw_results=raw_results,
+                center=coordinate,
+                min_distance_m=min_distance_m,
+                max_distance_m=max_distance_m,
+                source="query",
+            )
 
-        if len(hits_by_id) < resolved_target:
-            for query in self._fallback_queries:
-                if len(hits_by_id) >= resolved_target:
+        # 2. ファンアウト (searchLocation のみ、残り予算)
+        if len(hits_by_id) < resolved_target and calls < resolved_max_calls:
+            tolerance_ratio = resolved_tolerance / 100.0
+            search_radius = calculate_search_radius(radius_m, tolerance_ratio, MIN_SEARCH_RADIUS_M)
+            circle_points = generate_equidistant_circle_points(
+                coordinate,
+                radius_m,
+                float(search_radius),
+                seed=stable_search_seed(coordinate, radius_m) ^ 0xA5A5_5A5A,
+            )
+            for query_index, (point_lat, point_lng) in enumerate(circle_points):
+                if len(hits_by_id) >= resolved_target or calls >= resolved_max_calls:
                     break
-                query_results = self._search_by_query(
-                    region=region,
-                    query=query,
-                )
+                point = Coordinate(latitude=point_lat, longitude=point_lng)
+                query = queries[query_index % len(queries)]
+                raw_results = self._search_by_query_location(location=point, query=query)
+                calls += 1
                 self._merge_in_band_hits(
                     hits_by_id=hits_by_id,
-                    raw_results=query_results,
+                    raw_results=raw_results,
                     center=coordinate,
                     min_distance_m=min_distance_m,
                     max_distance_m=max_distance_m,
-                    source="query",
+                    source="fanout",
                 )
 
+        logger.debug(
+            "Apple landmark search done: hits=%s calls=%s/%s center=(%.4f,%.4f) radius=%s",
+            len(hits_by_id),
+            calls,
+            resolved_max_calls,
+            float(coordinate.latitude),
+            float(coordinate.longitude),
+            radius_m,
+        )
         return list(hits_by_id.values())
 
-    def _search_by_categories(
-        self,
-        *,
-        region: SearchRegion,
-        categories: list[str],
-    ) -> list[dict[str, Any]]:
-        """includePoiCategories でカテゴリ検索する。
-
-        q の扱い (スパイク時点の方針):
-        1. まず q を付けずにカテゴリのみで呼ぶ (category-only 仮説)
-        2. HTTP 400 なら汎用 q (CATEGORY_SEARCH_GENERIC_Q) を付けて再試行
-        空文字 q は送らない (Apple が拒否しうるパラメータを増やさない)。
-
-        地理ヒントは searchRegion のみ送る。
-        Apple は searchRegion と searchLocation の同時指定を 400 で拒否する。
-        """
-        params = self._base_search_params(region=region)
-        params["includePoiCategories"] = ",".join(categories)
-
-        try:
-            return self._get_search_results(params)
-        except ExternalServiceError as error:
-            if not self._is_bad_request(error):
-                raise
-            logger.info(
-                "Category search without q was rejected; retrying with generic q=%s",
-                self._category_generic_q,
-            )
-            params_with_q = dict(params)
-            params_with_q["q"] = self._category_generic_q
-            return self._get_search_results(params_with_q)
-
-    def _search_by_query(
+    def _search_by_query_region(
         self,
         *,
         region: SearchRegion,
         query: str,
     ) -> list[dict[str, Any]]:
-        """日本語クエリで同一 bbox を再検索する (フォールバック)。"""
-        params = self._base_search_params(region=region)
-        params["q"] = query
-        return self._get_search_results(params)
-
-    def _base_search_params(self, *, region: SearchRegion) -> dict[str, str]:
-        """共通クエリ。円近傍近似は searchRegion (bbox) のみ (searchLocation は送らない)。"""
-        return {
+        """searchRegion + 日本語 q (searchLocation は付けない)。"""
+        params = {
+            "q": query,
             "searchRegion": format_search_region(region),
             "resultTypeFilter": "Poi",
             "lang": "ja-JP",
             "limitToCountries": "JP",
         }
+        return self._get_search_results(params)
+
+    def _search_by_query_location(
+        self,
+        *,
+        location: Coordinate,
+        query: str,
+    ) -> list[dict[str, Any]]:
+        """searchLocation + 日本語 q (searchRegion は付けない)。"""
+        lat, lng = location.to_float_tuple()
+        params = {
+            "q": query,
+            "searchLocation": f"{lat},{lng}",
+            "resultTypeFilter": "Poi",
+            "lang": "ja-JP",
+            "limitToCountries": "JP",
+        }
+        return self._get_search_results(params)
 
     def _get_search_results(self, params: dict[str, str]) -> list[dict[str, Any]]:
-        access_token = self._token_provider.get_access_token()
+        access_token = self._provider().get_access_token()
         url = f"{self._base_url}/search"
         try:
             response = self._session.get(
@@ -351,7 +386,3 @@ class AppleMapsGatewayImpl(AppleMapsGateway):
             source=source,
             poi_category=poi_category,
         )
-
-    @staticmethod
-    def _is_bad_request(error: ExternalServiceError) -> bool:
-        return "HTTP 400" in error.message

--- a/backend/app/infrastructure/gateways/apple_maps_gateway_impl.py
+++ b/backend/app/infrastructure/gateways/apple_maps_gateway_impl.py
@@ -52,6 +52,8 @@ logger = logging.getLogger(__name__)
 
 SERVICE_NAME = "Apple Maps Server API"
 PLACE_ID_PREFIX = "apple:"
+# 例外メッセージ / ログに載せる Apple レスポンス本文の上限
+_MAX_ERROR_BODY_CHARS = 300
 
 # 1 度の緯度あたりのおよそのメートル (bbox 近似用)
 _METERS_PER_DEGREE_LAT = 111_320.0
@@ -75,6 +77,37 @@ REMAINING_QUERY_BAG: tuple[str, ...] = (
 )
 
 SearchRegion = tuple[float, float, float, float]  # north, east, south, west
+
+
+class AppleMapsHTTPError(ExternalServiceError):
+    """Apple Maps API の HTTP エラー (status_code を数値で保持する)
+
+    ステータス判定はメッセージ文字列ではなく status_code を使うこと。
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        service_name: str | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        """初期化
+
+        Args:
+            message: エラーメッセージ
+            service_name: サービス名
+            status_code: HTTP ステータスコード
+        """
+        self.status_code = status_code
+        super().__init__(message, service_name=service_name)
+
+
+def _truncate_error_body(text: str, *, limit: int = _MAX_ERROR_BODY_CHARS) -> str:
+    """例外メッセージ用にレスポンス本文を切り詰める。"""
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}...(truncated)"
 
 
 def circle_to_search_region(center: Coordinate, radius_m: float) -> SearchRegion:
@@ -307,9 +340,14 @@ class AppleMapsGatewayImpl(AppleMapsGateway):
             ) from error
         except HTTPError as error:
             status = error.response.status_code if error.response is not None else None
-            body = error.response.text if error.response is not None else ""
+            raw_body = error.response.text if error.response is not None else ""
+            body = _truncate_error_body(raw_body)
             message = f"Failed to search Apple Maps: HTTP {status} {body}".strip()
-            raise ExternalServiceError(message, service_name=SERVICE_NAME) from error
+            raise AppleMapsHTTPError(
+                message,
+                service_name=SERVICE_NAME,
+                status_code=status,
+            ) from error
         except RequestException as error:
             logger.error("Request error while calling Apple Maps /v1/search: %s", error)
             raise ExternalServiceError(

--- a/backend/app/infrastructure/gateways/apple_poi_category_mapping.py
+++ b/backend/app/infrastructure/gateways/apple_poi_category_mapping.py
@@ -1,0 +1,110 @@
+"""Google Places タイプ → Apple Maps PoiCategory の粗マッピング
+
+スパイク用。1:1 対応ではないため、複数 Google タイプを同一 Apple カテゴリへ畳み込む。
+Apple に無い語彙 (public_bath / japanese_inn / ferris_wheel 等) は Spa / Hotel / Landmark へ寄せる。
+
+参考: https://developer.apple.com/documentation/applemapsserverapi/poicategory
+"""
+
+from __future__ import annotations
+
+from app.config import LANDMARK_INCLUDED_TYPES
+
+# Google Places primary type → Apple PoiCategory
+# NOTE: public_bath→Spa, japanese_inn/cottage/resort_hotel→Hotel, ferris_wheel→Landmark は
+# Apple 側に相当カテゴリが無いための粗畳み込み (想定どおりのギャップ)。
+GOOGLE_TYPE_TO_APPLE_POI_CATEGORY: dict[str, str] = {
+    # 自然・屋外
+    "beach": "Beach",
+    "national_park": "NationalPark",
+    "state_park": "Park",
+    "park": "Park",
+    "city_park": "Park",
+    "garden": "Park",
+    "botanical_garden": "Park",
+    "hiking_area": "Hiking",
+    "picnic_ground": "Park",
+    "plaza": "Landmark",
+    "marina": "Marina",
+    # 文化・ランドマーク
+    "castle": "Castle",
+    "art_museum": "Museum",
+    "museum": "Museum",
+    "history_museum": "Museum",
+    "historical_landmark": "Landmark",
+    "performing_arts_theater": "Theater",
+    "concert_hall": "MusicVenue",
+    "opera_house": "MusicVenue",
+    "philharmonic_hall": "MusicVenue",
+    "planetarium": "Planetarium",
+    # エンタメ・映え
+    "amusement_park": "AmusementPark",
+    "aquarium": "Aquarium",
+    "ferris_wheel": "Landmark",  # Apple に FerrisWheel 無し
+    "observation_deck": "Landmark",
+    "amphitheatre": "Theater",
+    "cycling_park": "Park",
+    "skateboard_park": "SkatePark",
+    "dog_park": "Park",
+    # 軽い立ち寄り
+    "cafe": "Cafe",
+    "coffee_shop": "Cafe",
+    "coffee_stand": "Cafe",
+    "bakery": "Bakery",
+    "ice_cream_shop": "Cafe",
+    "dessert_shop": "Bakery",
+    "tea_house": "Cafe",
+    # 発見系
+    "book_store": "Store",
+    "gift_shop": "Store",
+    "market": "FoodMarket",
+    "farmers_market": "FoodMarket",
+    "flea_market": "Store",
+    "shopping_mall": "Store",
+    # チル
+    "spa": "Spa",
+    "sauna": "Spa",
+    "public_bath": "Spa",  # Apple に PublicBath 無し
+    # 非日常・雰囲気
+    "campground": "Campground",
+    "cottage": "Hotel",  # Apple に Cottage 無し
+    "japanese_inn": "Hotel",  # Apple に JapaneseInn 無し
+    "resort_hotel": "Hotel",
+}
+
+# Google リストに無いが snampo 向けに明示追加 (神社・寺院など)
+EXTRA_APPLE_POI_CATEGORIES: tuple[str, ...] = ("ReligiousSite",)
+
+
+def map_google_types_to_apple_poi_categories(
+    google_types: list[str] | None = None,
+    *,
+    include_religious_site: bool = True,
+) -> list[str]:
+    """Google タイプ一覧をユニークな Apple PoiCategory リストへ変換する。
+
+    Args:
+        google_types: Google Places タイプ (None なら LANDMARK_INCLUDED_TYPES)
+        include_religious_site: ReligiousSite を追加するか
+
+    Returns:
+        list[str]: 順序を保ったユニークな Apple PoiCategory
+    """
+    source = LANDMARK_INCLUDED_TYPES if google_types is None else google_types
+    categories: list[str] = []
+    seen: set[str] = set()
+
+    for google_type in source:
+        apple_category = GOOGLE_TYPE_TO_APPLE_POI_CATEGORY.get(google_type)
+        if apple_category is None or apple_category in seen:
+            continue
+        seen.add(apple_category)
+        categories.append(apple_category)
+
+    if include_religious_site:
+        for extra in EXTRA_APPLE_POI_CATEGORIES:
+            if extra not in seen:
+                seen.add(extra)
+                categories.append(extra)
+
+    return categories

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "tenacity>=9.1.2",
     "geopy>=2.4.1",
     "pydantic>=2.12.5",
+    "pyjwt[crypto]>=2.10.1",
 ]
 
 [build-system]

--- a/backend/scripts/probe_apple_maps_search.py
+++ b/backend/scripts/probe_apple_maps_search.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python3
-"""Apple Maps Server API のカテゴリ近傍検索をローカルから検証する probe。
+"""Apple Maps Server API の層別クエリ近傍検索をローカルから検証する probe。
 
-#235 の検索スパイク用。Directions / Street View / GenerateRouteUseCase には未接続。
+#235 目的地ランドマーク検索 (本番は LandmarkSearchService → AppleMapsGateway)。
+Directions / Street View / Roads / 中間地点検索は Google のまま。
 
 ## 事前準備 (Maps Server API キー)
 
 1. [Apple Developer](https://developer.apple.com/account) にログイン
-2. Identifiers → Maps IDs で Maps ID を作成 (例: `maps.com.example.snampo`)
-3. Keys → MapKit JS を有効化し、上記 Maps ID を Configure で紐づけて `.p8` を Download
-4. Membership の Team ID と Keys の Key ID を控える
-5. `backend/.env.example` を参考に `backend/.env` へ設定し、`.p8` を git 管理外へ配置
+2. Identifiers → Maps IDs で Maps ID を作成
+3. Keys → MapKit JS を有効化し Maps ID を紐づけて `.p8` を Download
+4. `backend/.env.example` を参考に設定
 
 環境変数:
   APPLE_TEAM_ID
   APPLE_MAPS_KEY_ID
-  APPLE_MAPS_PRIVATE_KEY_PATH
-  APPLE_MAPS_ID  (任意。鍵作成時の Maps ID 追跡用。JWT には含めない)
+  APPLE_MAPS_PRIVATE_KEY       (PEM 文字列。Cloud Run / Secret Manager 向け。優先)
+  APPLE_MAPS_PRIVATE_KEY_PATH  (ローカル .p8。PEM が無いときのフォールバック)
+  APPLE_MAPS_ID                (任意。鍵作成時の Maps ID 追跡用)
 
 ## 使い方
 
@@ -31,8 +32,7 @@ uv run python scripts/probe_apple_maps_search.py --fixture all --json
 ## 成功の目安
 
 箱根 (~35.232, 139.107) や栗橋/久喜 (~36.122, 139.700) で、目標距離 ±15% 帯に
-複数の POI (公園・神社・カフェ等) が返り、後続で Street View 取得候補になりうること。
-source 列が `category` / `query` のどちらで拾えたかも確認する。
+複数の POI が返り、`source` が `query` / `fanout` のどちらで拾えたか確認できること。
 """
 
 from __future__ import annotations
@@ -56,9 +56,11 @@ if "GOOGLE_API_KEY" not in os.environ:
 
 from app.config import (  # noqa: E402
     APPLE_MAPS_KEY_ID,
+    APPLE_MAPS_PRIVATE_KEY,
     APPLE_MAPS_PRIVATE_KEY_PATH,
     APPLE_TEAM_ID,
     LANDMARK_DISTANCE_TOLERANCE_PERCENT,
+    LANDMARK_SEARCH_MAX_CALLS,
     LANDMARK_SEARCH_TARGET_COUNT,
 )
 from app.domain.value_objects import Coordinate  # noqa: E402
@@ -68,9 +70,8 @@ from app.infrastructure.gateways.apple_maps_auth import (  # noqa: E402
 )
 from app.infrastructure.gateways.apple_maps_gateway_impl import (  # noqa: E402
     AppleMapsGatewayImpl,
-)
-from app.infrastructure.gateways.apple_poi_category_mapping import (  # noqa: E402
-    map_google_types_to_apple_poi_categories,
+    build_stratified_query_bag,
+    stable_search_seed,
 )
 
 DEFAULT_FIXTURES: dict[str, tuple[float, float, int, str]] = {
@@ -89,6 +90,7 @@ def _build_gateway() -> AppleMapsGatewayImpl:
     provider = AppleMapsTokenProvider.from_env(
         team_id=APPLE_TEAM_ID or os.environ.get("APPLE_TEAM_ID"),
         key_id=APPLE_MAPS_KEY_ID or os.environ.get("APPLE_MAPS_KEY_ID"),
+        private_key_pem=APPLE_MAPS_PRIVATE_KEY or os.environ.get("APPLE_MAPS_PRIVATE_KEY"),
         private_key_path=APPLE_MAPS_PRIVATE_KEY_PATH
         or os.environ.get("APPLE_MAPS_PRIVATE_KEY_PATH"),
         backend_dir=_BACKEND_DIR,
@@ -122,11 +124,14 @@ def _run_one(
     as_json: bool,
 ) -> dict:
     center = Coordinate(latitude=lat, longitude=lng)
+    seed = stable_search_seed(center, radius_m)
+    queries = build_stratified_query_bag(seed)
     hits = gateway.search_landmarks_nearby(
         center,
         radius_m,
         target_count=LANDMARK_SEARCH_TARGET_COUNT,
         distance_tolerance_percent=LANDMARK_DISTANCE_TOLERANCE_PERCENT,
+        max_calls=LANDMARK_SEARCH_MAX_CALLS,
     )
     payload = {
         "label": label,
@@ -134,7 +139,8 @@ def _run_one(
         "radius_m": radius_m,
         "tolerance_percent": LANDMARK_DISTANCE_TOLERANCE_PERCENT,
         "target_count": LANDMARK_SEARCH_TARGET_COUNT,
-        "apple_poi_categories": map_google_types_to_apple_poi_categories(),
+        "max_calls": LANDMARK_SEARCH_MAX_CALLS,
+        "query_bag_preview": queries[:8],
         "hit_count": len(hits),
         "hits": [
             {
@@ -158,15 +164,17 @@ def _run_one(
         print(
             f"in-band hits={len(hits)} "
             f"(target>={LANDMARK_SEARCH_TARGET_COUNT}, "
-            f"band=±{LANDMARK_DISTANCE_TOLERANCE_PERCENT}%)"
+            f"band=±{LANDMARK_DISTANCE_TOLERANCE_PERCENT}%, "
+            f"max_calls={LANDMARK_SEARCH_MAX_CALLS})"
         )
+        print(f"query bag head: {queries[:5]}")
     return payload
 
 
 def main(argv: list[str] | None = None) -> int:
     """probe を実行する。"""
     parser = argparse.ArgumentParser(
-        description="Probe Apple Maps category+fallback landmark search (#235 spike)"
+        description="Probe Apple Maps stratified query landmark search (#235)"
     )
     parser.add_argument("--lat", type=float, help="中心緯度")
     parser.add_argument("--lng", type=float, help="中心経度")
@@ -204,7 +212,7 @@ def main(argv: list[str] | None = None) -> int:
 
     results: list[dict] = []
 
-    if args.fixture == "all":
+    if args.fixture == "all" or (args.fixture is None and args.lat is None):
         for name, (lat, lng, radius_m, description) in DEFAULT_FIXTURES.items():
             results.append(
                 _run_one(
@@ -240,18 +248,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     else:
-        # デフォルト: 3 フィクスチャを順に実行
-        for name, (lat, lng, radius_m, description) in DEFAULT_FIXTURES.items():
-            results.append(
-                _run_one(
-                    gateway,
-                    lat=lat,
-                    lng=lng,
-                    radius_m=args.radius_m if args.radius_m is not None else radius_m,
-                    label=f"{name}: {description}",
-                    as_json=args.json,
-                )
-            )
+        parser.error("--lat/--lng か --fixture を指定してください")
 
     if args.save:
         output_path = _BACKEND_DIR / "apple_maps_search_probe_result.json"

--- a/backend/scripts/probe_apple_maps_search.py
+++ b/backend/scripts/probe_apple_maps_search.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Apple Maps Server API のカテゴリ近傍検索をローカルから検証する probe。
+
+#235 の検索スパイク用。Directions / Street View / GenerateRouteUseCase には未接続。
+
+## 事前準備 (Maps Server API キー)
+
+1. [Apple Developer](https://developer.apple.com/account) にログイン
+2. Identifiers → Maps IDs で Maps ID を作成 (例: `maps.com.example.snampo`)
+3. Keys → MapKit JS を有効化し、上記 Maps ID を Configure で紐づけて `.p8` を Download
+4. Membership の Team ID と Keys の Key ID を控える
+5. `backend/.env.example` を参考に `backend/.env` へ設定し、`.p8` を git 管理外へ配置
+
+環境変数:
+  APPLE_TEAM_ID
+  APPLE_MAPS_KEY_ID
+  APPLE_MAPS_PRIVATE_KEY_PATH
+  APPLE_MAPS_ID  (任意。鍵作成時の Maps ID 追跡用。JWT には含めない)
+
+## 使い方
+
+```bash
+cd backend
+uv run python scripts/probe_apple_maps_search.py
+uv run python scripts/probe_apple_maps_search.py --lat 35.232 --lng 139.107 --radius-m 2000
+uv run python scripts/probe_apple_maps_search.py --fixture all --json
+```
+
+認証情報が無い場合は非ゼロ終了し、単体テストには影響しない。
+
+## 成功の目安
+
+箱根 (~35.232, 139.107) や栗橋/久喜 (~36.122, 139.700) で、目標距離 ±15% 帯に
+複数の POI (公園・神社・カフェ等) が返り、後続で Street View 取得候補になりうること。
+source 列が `category` / `query` のどちらで拾えたかも確認する。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# backend/ を import パスへ
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+# app.config が GOOGLE_API_KEY を要求するため、未設定時はダミーを入れる (本スクリプトでは未使用)
+if "GOOGLE_API_KEY" not in os.environ:
+    os.environ["GOOGLE_API_KEY"] = "dummy-key-for-apple-maps-search-probe"
+
+from app.config import (  # noqa: E402
+    APPLE_MAPS_KEY_ID,
+    APPLE_MAPS_PRIVATE_KEY_PATH,
+    APPLE_TEAM_ID,
+    LANDMARK_DISTANCE_TOLERANCE_PERCENT,
+    LANDMARK_SEARCH_TARGET_COUNT,
+)
+from app.domain.value_objects import Coordinate  # noqa: E402
+from app.infrastructure.gateways.apple_maps_auth import (  # noqa: E402
+    AppleMapsCredentialsError,
+    AppleMapsTokenProvider,
+)
+from app.infrastructure.gateways.apple_maps_gateway_impl import (  # noqa: E402
+    AppleMapsGatewayImpl,
+)
+from app.infrastructure.gateways.apple_poi_category_mapping import (  # noqa: E402
+    map_google_types_to_apple_poi_categories,
+)
+
+DEFAULT_FIXTURES: dict[str, tuple[float, float, int, str]] = {
+    # name -> (lat, lng, radius_m, description)
+    "hakone": (35.232, 139.107, 2000, "箱根 (観光密集)"),
+    "kurihashi": (36.122, 139.700, 2500, "栗橋/久喜付近"),
+    "rural": (36.650, 138.190, 3000, "疎な山間寄り (長野寄り)"),
+}
+
+
+def _load_env() -> None:
+    load_dotenv(_BACKEND_DIR / ".env")
+
+
+def _build_gateway() -> AppleMapsGatewayImpl:
+    provider = AppleMapsTokenProvider.from_env(
+        team_id=APPLE_TEAM_ID or os.environ.get("APPLE_TEAM_ID"),
+        key_id=APPLE_MAPS_KEY_ID or os.environ.get("APPLE_MAPS_KEY_ID"),
+        private_key_path=APPLE_MAPS_PRIVATE_KEY_PATH
+        or os.environ.get("APPLE_MAPS_PRIVATE_KEY_PATH"),
+        backend_dir=_BACKEND_DIR,
+    )
+    return AppleMapsGatewayImpl(provider)
+
+
+def _print_table(hits: list, *, center_label: str) -> None:
+    print(f"\n=== {center_label} ===")
+    print(f"{'source':<10} {'distance_m':>10} {'category':<16} {'name':<28} coordinate")
+    print("-" * 100)
+    if not hits:
+        print("(no in-band hits)")
+        return
+    for hit in hits:
+        category = hit.poi_category or "-"
+        coord = f"{hit.coordinate.latitude:.5f},{hit.coordinate.longitude:.5f}"
+        print(
+            f"{hit.source:<10} {hit.distance_m:10.1f} {category:<16} "
+            f"{hit.display_name[:28]:<28} {coord}"
+        )
+
+
+def _run_one(
+    gateway: AppleMapsGatewayImpl,
+    *,
+    lat: float,
+    lng: float,
+    radius_m: int,
+    label: str,
+    as_json: bool,
+) -> dict:
+    center = Coordinate(latitude=lat, longitude=lng)
+    hits = gateway.search_landmarks_nearby(
+        center,
+        radius_m,
+        target_count=LANDMARK_SEARCH_TARGET_COUNT,
+        distance_tolerance_percent=LANDMARK_DISTANCE_TOLERANCE_PERCENT,
+    )
+    payload = {
+        "label": label,
+        "center": {"latitude": lat, "longitude": lng},
+        "radius_m": radius_m,
+        "tolerance_percent": LANDMARK_DISTANCE_TOLERANCE_PERCENT,
+        "target_count": LANDMARK_SEARCH_TARGET_COUNT,
+        "apple_poi_categories": map_google_types_to_apple_poi_categories(),
+        "hit_count": len(hits),
+        "hits": [
+            {
+                "source": hit.source,
+                "name": hit.display_name,
+                "category": hit.poi_category,
+                "distance_m": round(hit.distance_m, 1),
+                "place_id": hit.place_id,
+                "coordinate": {
+                    "latitude": hit.coordinate.latitude,
+                    "longitude": hit.coordinate.longitude,
+                },
+            }
+            for hit in hits
+        ],
+    }
+    if as_json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        _print_table(hits, center_label=label)
+        print(
+            f"in-band hits={len(hits)} "
+            f"(target>={LANDMARK_SEARCH_TARGET_COUNT}, "
+            f"band=±{LANDMARK_DISTANCE_TOLERANCE_PERCENT}%)"
+        )
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    """probe を実行する。"""
+    parser = argparse.ArgumentParser(
+        description="Probe Apple Maps category+fallback landmark search (#235 spike)"
+    )
+    parser.add_argument("--lat", type=float, help="中心緯度")
+    parser.add_argument("--lng", type=float, help="中心経度")
+    parser.add_argument(
+        "--radius-m",
+        type=int,
+        default=None,
+        help="目標距離 (m)。未指定時は fixture 既定値、または custom なら 2000",
+    )
+    parser.add_argument(
+        "--fixture",
+        choices=[*DEFAULT_FIXTURES.keys(), "all"],
+        help="組み込み地点 (hakone / kurihashi / rural / all)",
+    )
+    parser.add_argument("--json", action="store_true", help="JSON で出力")
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="backend/apple_maps_search_probe_result.json に保存",
+    )
+    args = parser.parse_args(argv)
+
+    _load_env()
+
+    try:
+        gateway = _build_gateway()
+    except AppleMapsCredentialsError as error:
+        print(f"エラー: {error}", file=sys.stderr)
+        print(
+            "Apple Maps 認証情報が無いため probe を中止します。"
+            "単体テスト (mocked HTTP) は認証なしで実行できます。",
+            file=sys.stderr,
+        )
+        return 1
+
+    results: list[dict] = []
+
+    if args.fixture == "all":
+        for name, (lat, lng, radius_m, description) in DEFAULT_FIXTURES.items():
+            results.append(
+                _run_one(
+                    gateway,
+                    lat=lat,
+                    lng=lng,
+                    radius_m=args.radius_m if args.radius_m is not None else radius_m,
+                    label=f"{name}: {description}",
+                    as_json=args.json,
+                )
+            )
+    elif args.fixture:
+        lat, lng, radius_m, description = DEFAULT_FIXTURES[args.fixture]
+        results.append(
+            _run_one(
+                gateway,
+                lat=lat,
+                lng=lng,
+                radius_m=args.radius_m if args.radius_m is not None else radius_m,
+                label=f"{args.fixture}: {description}",
+                as_json=args.json,
+            )
+        )
+    elif args.lat is not None and args.lng is not None:
+        results.append(
+            _run_one(
+                gateway,
+                lat=args.lat,
+                lng=args.lng,
+                radius_m=args.radius_m if args.radius_m is not None else 2000,
+                label=f"custom ({args.lat},{args.lng})",
+                as_json=args.json,
+            )
+        )
+    else:
+        # デフォルト: 3 フィクスチャを順に実行
+        for name, (lat, lng, radius_m, description) in DEFAULT_FIXTURES.items():
+            results.append(
+                _run_one(
+                    gateway,
+                    lat=lat,
+                    lng=lng,
+                    radius_m=args.radius_m if args.radius_m is not None else radius_m,
+                    label=f"{name}: {description}",
+                    as_json=args.json,
+                )
+            )
+
+    if args.save:
+        output_path = _BACKEND_DIR / "apple_maps_search_probe_result.json"
+        output_path.write_text(
+            json.dumps(results, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(f"\nSaved: {output_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        raise SystemExit(130) from None

--- a/backend/tests/app/application/services/test_landmark_search_service.py
+++ b/backend/tests/app/application/services/test_landmark_search_service.py
@@ -1,0 +1,67 @@
+"""LandmarkSearchService のテスト (Apple Gateway をモック)"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.application.gateway_interfaces.apple_maps_gateway import AppleSearchHit
+from app.application.services.landmark_search_service import LandmarkSearchService
+from app.domain.exceptions import ExternalServiceError
+from app.domain.value_objects import Coordinate
+
+
+class TestLandmarkSearchService:
+    """Apple 経由の目的地ランドマーク検索"""
+
+    def test_ヒットをLandmarkに変換して返すこと(self) -> None:
+        """Gateway のヒットが Landmark になる。"""
+        center = Coordinate(latitude=35.232, longitude=139.107)
+        hit_coord = Coordinate(latitude=35.240, longitude=139.110)
+        gateway = MagicMock()
+        gateway.search_landmarks_nearby.return_value = [
+            AppleSearchHit(
+                place_id="apple:1",
+                display_name="箱根公園",
+                coordinate=hit_coord,
+                distance_m=2000.0,
+                source="query",
+                poi_category="Park",
+            )
+        ]
+        service = LandmarkSearchService(gateway)
+
+        landmarks = service.search_landmarks(
+            center=center,
+            target_distance_m=2000,
+            target_count=5,
+            max_calls=8,
+        )
+
+        assert len(landmarks) == 1
+        assert landmarks[0].place_id == "apple:1"
+        assert landmarks[0].display_name == "箱根公園"
+        gateway.search_landmarks_nearby.assert_called_once_with(
+            center,
+            2000,
+            target_count=5,
+            max_calls=8,
+        )
+
+    def test_外部エラー時は空リストを返すこと(self) -> None:
+        """Gateway 失敗でもルート生成側が続行できるよう空配列。"""
+        gateway = MagicMock()
+        gateway.search_landmarks_nearby.side_effect = ExternalServiceError(
+            "boom", service_name="Apple Maps Server API"
+        )
+        service = LandmarkSearchService(gateway)
+        center = Coordinate(latitude=35.0, longitude=139.0)
+
+        assert (
+            service.search_landmarks(
+                center=center,
+                target_distance_m=2000,
+                target_count=5,
+                max_calls=8,
+            )
+            == []
+        )

--- a/backend/tests/app/infrastructure/gateways/test_apple_maps_gateway.py
+++ b/backend/tests/app/infrastructure/gateways/test_apple_maps_gateway.py
@@ -1,4 +1,4 @@
-"""Apple Maps Gateway / Auth / マッピングのテスト (HTTP はモック、ネットワーク無し)"""
+"""Apple Maps Gateway / Auth / クエリバッグのテスト (HTTP はモック、ネットワーク無し)"""
 
 from __future__ import annotations
 
@@ -20,12 +20,16 @@ from app.infrastructure.gateways.apple_maps_auth import (
     AppleMapsTokenProvider,
 )
 from app.infrastructure.gateways.apple_maps_gateway_impl import (
-    CATEGORY_SEARCH_GENERIC_Q,
+    CASUAL_QUERY_BUCKET,
+    CULTURE_QUERY_BUCKET,
+    OUTDOOR_QUERY_BUCKET,
     AppleMapsGatewayImpl,
+    build_stratified_query_bag,
     circle_to_search_region,
     distance_band_bounds,
     format_search_region,
     prefix_apple_place_id,
+    stable_search_seed,
 )
 from app.infrastructure.gateways.apple_poi_category_mapping import (
     GOOGLE_TYPE_TO_APPLE_POI_CATEGORY,
@@ -64,7 +68,7 @@ def token_provider(es256_pem: str) -> AppleMapsTokenProvider:
 
 
 class TestApplePoiCategoryMapping:
-    """Google → Apple カテゴリマッピング"""
+    """Google → Apple カテゴリマッピング (参照用、検索本番では未使用)"""
 
     def test_LANDMARKタイプがユニークなAppleカテゴリに畳み込まれること(self) -> None:
         """複数 Google タイプが同一 Apple カテゴリへ重複なく畳み込まれる。"""
@@ -107,6 +111,27 @@ class TestBboxAndDistanceBand:
         """Google place_id と衝突しないよう prefix する。"""
         assert prefix_apple_place_id("I123") == "apple:I123"
         assert prefix_apple_place_id("apple:I123") == "apple:I123"
+
+
+class TestStratifiedQueryBag:
+    """層別クエリバッグ"""
+
+    def test_固定シードで先頭3件が各バケットから1つであること(self) -> None:
+        """outdoor / culture / casual から 1 件ずつが先頭に並ぶ。"""
+        bag = build_stratified_query_bag(42)
+        assert bag[0] in OUTDOOR_QUERY_BUCKET
+        assert bag[1] in CULTURE_QUERY_BUCKET
+        assert bag[2] in CASUAL_QUERY_BUCKET
+
+    def test_同一シードは同一順序であること(self) -> None:
+        """再現可能なシャッフルになる。"""
+        assert build_stratified_query_bag(99) == build_stratified_query_bag(99)
+
+    def test_中心と半径から安定シードが得られること(self) -> None:
+        """同じ中心・半径なら同じシード。"""
+        center = Coordinate(latitude=35.232, longitude=139.107)
+        assert stable_search_seed(center, 2000) == stable_search_seed(center, 2000)
+        assert stable_search_seed(center, 2000) != stable_search_seed(center, 2500)
 
 
 class TestAppleMapsTokenProvider:
@@ -171,19 +196,56 @@ class TestAppleMapsTokenProvider:
         assert token_provider.get_access_token(now=50.0) == "token-b"
         assert token_provider._session.get.call_count == 2
 
+    def test_PEM環境変数からProviderを構築できること(self, es256_pem: str) -> None:
+        """APPLE_MAPS_PRIVATE_KEY (PEM) を優先して読める。"""
+        provider = AppleMapsTokenProvider.from_env(
+            team_id="TEAM12ABCD",
+            key_id="KEY12ABCDE",
+            private_key_pem=es256_pem,
+            private_key_path=None,
+        )
+        token = provider.create_maps_auth_token(now=1_700_000_000)
+        assert isinstance(token, str)
+        assert token.count(".") == 2
+
+    def test_PEMが無くパスがあればファイルから読むこと(
+        self, es256_pem: str, tmp_path: Path
+    ) -> None:
+        """APPLE_MAPS_PRIVATE_KEY_PATH フォールバック。"""
+        key_file = tmp_path / "AuthKey_TEST.p8"
+        key_file.write_text(es256_pem, encoding="utf-8")
+        provider = AppleMapsTokenProvider.from_env(
+            team_id="TEAM12ABCD",
+            key_id="KEY12ABCDE",
+            private_key_pem=None,
+            private_key_path=str(key_file),
+            backend_dir=tmp_path,
+        )
+        assert provider.create_maps_auth_token(now=1_700_000_000)
+
     def test_認証情報不足でCredentialsErrorになること(self, tmp_path: Path) -> None:
         """必須 env が無いとき明確なエラーになる。"""
         with pytest.raises(AppleMapsCredentialsError, match="APPLE_TEAM_ID"):
             AppleMapsTokenProvider.from_env(
                 team_id=None,
                 key_id="KEY",
-                private_key_path=str(tmp_path / "missing.p8"),
+                private_key_pem="-----BEGIN PRIVATE KEY-----\nX\n-----END PRIVATE KEY-----",
                 backend_dir=tmp_path,
+            )
+
+    def test_秘密鍵が無いとCredentialsErrorになること(self) -> None:
+        """PEM もパスも無いときエラーになる。"""
+        with pytest.raises(AppleMapsCredentialsError, match="APPLE_MAPS_PRIVATE_KEY"):
+            AppleMapsTokenProvider.from_env(
+                team_id="TEAM12ABCD",
+                key_id="KEY12ABCDE",
+                private_key_pem=None,
+                private_key_path=None,
             )
 
 
 class TestAppleMapsGatewaySearch:
-    """カテゴリ検索 / フォールバック / dedup"""
+    """層別クエリ / 早期停止 / ファンアウト / dedup"""
 
     @pytest.fixture
     def gateway(self, token_provider: AppleMapsTokenProvider) -> AppleMapsGatewayImpl:
@@ -199,7 +261,6 @@ class TestAppleMapsGatewaySearch:
             token_provider,
             base_url="https://maps-api.apple.test/v1",
             session=MagicMock(),
-            fallback_queries=("公園", "神社"),
         )
 
     def _point_at_distance(
@@ -213,191 +274,124 @@ class TestAppleMapsGatewaySearch:
         lng = float(center.longitude) + (distance_m / meters_per_degree_lng) * math.sin(radians)
         return Coordinate(latitude=lat, longitude=lng)
 
-    def test_カテゴリ検索で距離帯内のPOIが返ること(self, gateway: AppleMapsGatewayImpl) -> None:
-        """カテゴリ検索結果を距離帯で絞り、q 無しで呼ぶ。"""
-        center = Coordinate(latitude=35.232, longitude=139.107)
-        in_band = self._point_at_distance(center, 2000.0)
-        out_of_band = self._point_at_distance(center, 500.0)
-
-        search_response = MagicMock()
-        search_response.raise_for_status = MagicMock()
-        search_response.json.return_value = {
-            "results": [
-                {
-                    "id": "park-1",
-                    "name": "箱根公園",
-                    "poiCategory": "Park",
-                    "coordinate": {
-                        "latitude": in_band.latitude,
-                        "longitude": in_band.longitude,
-                    },
-                },
-                {
-                    "id": "cafe-near",
-                    "name": "近すぎるカフェ",
-                    "poiCategory": "Cafe",
-                    "coordinate": {
-                        "latitude": out_of_band.latitude,
-                        "longitude": out_of_band.longitude,
-                    },
-                },
-            ]
-        }
-        gateway._session.get.return_value = search_response
-
-        hits = gateway.search_landmarks_nearby(
-            center, 2000, target_count=1, distance_tolerance_percent=15.0
-        )
-        assert len(hits) == 1
-        assert hits[0].place_id == "apple:park-1"
-        assert hits[0].source == "category"
-        assert hits[0].display_name == "箱根公園"
-
-        first_params = gateway._session.get.call_args_list[0].kwargs["params"]
-        assert "includePoiCategories" in first_params
-        assert "searchRegion" in first_params
-        assert "searchLocation" not in first_params
-        assert "q" not in first_params
-        assert first_params["resultTypeFilter"] == "Poi"
-        assert first_params["lang"] == "ja-JP"
-        assert first_params["limitToCountries"] == "JP"
-
-    def test_カテゴリ検索が400なら汎用qで再試行すること(
-        self, gateway: AppleMapsGatewayImpl
-    ) -> None:
-        """q 省略が拒否されたら汎用 q でリトライする。"""
-        center = Coordinate(latitude=35.0, longitude=139.0)
-        in_band = self._point_at_distance(center, 2000.0)
-
-        bad_response = MagicMock()
-        bad_response.status_code = 400
-        bad_response.text = "q is required"
-        http_error = HTTPError(response=bad_response)
-        bad_response.raise_for_status.side_effect = http_error
-
-        ok_response = MagicMock()
-        ok_response.raise_for_status = MagicMock()
-        ok_response.json.return_value = {
-            "results": [
-                {
-                    "id": "spot-1",
-                    "name": "スポットA",
-                    "poiCategory": "Park",
-                    "coordinate": {
-                        "latitude": in_band.latitude,
-                        "longitude": in_band.longitude,
-                    },
-                }
-            ]
-        }
-        gateway._session.get.side_effect = [bad_response, ok_response]
-
-        hits = gateway.search_landmarks_nearby(
-            center, 2000, target_count=1, distance_tolerance_percent=15.0
-        )
-        assert len(hits) == 1
-        second_params = gateway._session.get.call_args_list[1].kwargs["params"]
-        assert second_params["q"] == CATEGORY_SEARCH_GENERIC_Q
-        assert "searchRegion" in second_params
-        assert "searchLocation" not in second_params
-
-    def test_件数不足時にクエリバッグへフォールバックすること(
-        self, gateway: AppleMapsGatewayImpl
-    ) -> None:
-        """カテゴリで足りないとき日本語クエリバッグを使う。"""
-        center = Coordinate(latitude=36.122, longitude=139.700)
-        in_band = self._point_at_distance(center, 2500.0)
-
-        empty_category = MagicMock()
-        empty_category.raise_for_status = MagicMock()
-        empty_category.json.return_value = {"results": []}
-
-        empty_query = MagicMock()
-        empty_query.raise_for_status = MagicMock()
-        empty_query.json.return_value = {"results": []}
-
-        query_hit = MagicMock()
-        query_hit.raise_for_status = MagicMock()
-        query_hit.json.return_value = {
-            "results": [
-                {
-                    "id": "shrine-1",
-                    "name": "久喜神社",
-                    "poiCategory": "ReligiousSite",
-                    "coordinate": {
-                        "latitude": in_band.latitude,
-                        "longitude": in_band.longitude,
-                    },
-                }
-            ]
-        }
-        gateway._session.get.side_effect = [empty_category, empty_query, query_hit]
-
-        hits = gateway.search_landmarks_nearby(
-            center, 2500, target_count=1, distance_tolerance_percent=15.0
-        )
-        assert len(hits) == 1
-        assert hits[0].source == "query"
-        assert hits[0].place_id == "apple:shrine-1"
-
-        query_params = gateway._session.get.call_args_list[2].kwargs["params"]
-        assert query_params["q"] == "神社"
-        assert "searchRegion" in query_params
-        assert "searchLocation" not in query_params
-
-    def test_同一place_idはdedupされること(self, gateway: AppleMapsGatewayImpl) -> None:
-        """カテゴリとクエリで同じ id が出ても 1 件にまとめる。"""
-        center = Coordinate(latitude=35.232, longitude=139.107)
-        in_band = self._point_at_distance(center, 2000.0)
-        payload = {
-            "results": [
-                {
-                    "id": "dup-1",
-                    "name": "同じ場所",
-                    "poiCategory": "Park",
-                    "coordinate": {
-                        "latitude": in_band.latitude,
-                        "longitude": in_band.longitude,
-                    },
-                }
-            ]
-        }
-        response = MagicMock()
-        response.raise_for_status = MagicMock()
-        response.json.return_value = payload
-        gateway._session.get.return_value = response
-
-        hits = gateway.search_landmarks_nearby(
-            center, 2000, target_count=5, distance_tolerance_percent=15.0
-        )
-        assert len(hits) == 1
-        assert hits[0].place_id == "apple:dup-1"
-
-    def test_認証なしでもモジュールimportとマッピングは動くこと(self) -> None:
-        """Apple 認証が無くてもマッピング単体は動く。"""
-        categories = map_google_types_to_apple_poi_categories(["park", "cafe"])
-        assert categories == ["Park", "Cafe", "ReligiousSite"]
-
-    def test_id欠落の結果はスキップすること(self, gateway: AppleMapsGatewayImpl) -> None:
-        """id が無い POI は採用しない。"""
-        center = Coordinate(latitude=35.0, longitude=139.0)
-        in_band = self._point_at_distance(center, 2000.0)
+    def _poi_response(self, place_id: str, name: str, coordinate: Coordinate) -> MagicMock:
+        """1 件の検索レスポンスを作る。"""
         response = MagicMock()
         response.raise_for_status = MagicMock()
         response.json.return_value = {
             "results": [
                 {
-                    "name": "IDなし",
+                    "id": place_id,
+                    "name": name,
+                    "poiCategory": "Park",
                     "coordinate": {
-                        "latitude": in_band.latitude,
-                        "longitude": in_band.longitude,
+                        "latitude": coordinate.latitude,
+                        "longitude": coordinate.longitude,
                     },
                 }
             ]
         }
-        gateway._session.get.return_value = response
+        return response
+
+    def test_クエリ検索はsearchRegionのみでsearchLocationを付けないこと(
+        self, gateway: AppleMapsGatewayImpl
+    ) -> None:
+        """本番クエリフェーズのパラメータ制約。"""
+        center = Coordinate(latitude=35.232, longitude=139.107)
+        in_band = self._point_at_distance(center, 2000.0)
+        gateway._session.get.return_value = self._poi_response("park-1", "箱根公園", in_band)
+
         hits = gateway.search_landmarks_nearby(
-            center, 2000, target_count=1, distance_tolerance_percent=15.0
+            center, 2000, target_count=1, distance_tolerance_percent=15.0, max_calls=1
+        )
+        assert len(hits) == 1
+        assert hits[0].source == "query"
+        params = gateway._session.get.call_args.kwargs["params"]
+        assert "q" in params
+        assert "searchRegion" in params
+        assert "searchLocation" not in params
+        assert params["resultTypeFilter"] == "Poi"
+        assert params["lang"] == "ja-JP"
+        assert params["limitToCountries"] == "JP"
+
+    def test_目標件数到達で早期停止すること(self, gateway: AppleMapsGatewayImpl) -> None:
+        """target_count に達したら残クエリを呼ばない。"""
+        center = Coordinate(latitude=35.232, longitude=139.107)
+        in_band = self._point_at_distance(center, 2000.0)
+        gateway._session.get.return_value = self._poi_response("park-1", "箱根公園", in_band)
+
+        hits = gateway.search_landmarks_nearby(
+            center, 2000, target_count=1, distance_tolerance_percent=15.0, max_calls=8
+        )
+        assert len(hits) == 1
+        assert gateway._session.get.call_count == 1
+
+    def test_件数不足時にファンアウトでsearchLocationのみ使うこと(
+        self, gateway: AppleMapsGatewayImpl
+    ) -> None:
+        """クエリで 0 件のあと、円周ファンアウトが searchLocation のみ送る。"""
+        center = Coordinate(latitude=36.122, longitude=139.700)
+        in_band = self._point_at_distance(center, 2500.0)
+
+        empty = MagicMock()
+        empty.raise_for_status = MagicMock()
+        empty.json.return_value = {"results": []}
+
+        fanout_hit = self._poi_response("shrine-1", "久喜神社", in_band)
+
+        def side_effect(*_args: object, **kwargs: object) -> MagicMock:
+            params = kwargs.get("params", {})
+            assert isinstance(params, dict)
+            if "searchLocation" in params:
+                assert "searchRegion" not in params
+                return fanout_hit
+            assert "searchRegion" in params
+            assert "searchLocation" not in params
+            return empty
+
+        gateway._session.get.side_effect = side_effect
+
+        hits = gateway.search_landmarks_nearby(
+            center, 2500, target_count=1, distance_tolerance_percent=15.0, max_calls=20
+        )
+        assert len(hits) == 1
+        assert hits[0].source == "fanout"
+        assert hits[0].place_id == "apple:shrine-1"
+
+    def test_max_callsを超えてクエリを投げないこと(self, gateway: AppleMapsGatewayImpl) -> None:
+        """HTTP 予算を守り、全クエリバッグを回し切らない。"""
+        center = Coordinate(latitude=35.0, longitude=139.0)
+        empty = MagicMock()
+        empty.raise_for_status = MagicMock()
+        empty.json.return_value = {"results": []}
+        gateway._session.get.return_value = empty
+
+        hits = gateway.search_landmarks_nearby(
+            center, 2000, target_count=5, distance_tolerance_percent=15.0, max_calls=3
+        )
+        assert hits == []
+        assert gateway._session.get.call_count == 3
+
+    def test_同一place_idはdedupされること(self, gateway: AppleMapsGatewayImpl) -> None:
+        """同じ id は 1 件にまとめる。"""
+        center = Coordinate(latitude=35.232, longitude=139.107)
+        in_band = self._point_at_distance(center, 2000.0)
+        gateway._session.get.return_value = self._poi_response("dup-1", "同じ場所", in_band)
+
+        hits = gateway.search_landmarks_nearby(
+            center, 2000, target_count=5, distance_tolerance_percent=15.0, max_calls=2
+        )
+        assert len(hits) == 1
+        assert hits[0].place_id == "apple:dup-1"
+
+    def test_距離帯外は除外すること(self, gateway: AppleMapsGatewayImpl) -> None:
+        """近すぎる POI は距離帯フィルタで落とす。"""
+        center = Coordinate(latitude=35.232, longitude=139.107)
+        near = self._point_at_distance(center, 500.0)
+        gateway._session.get.return_value = self._poi_response("near-1", "近すぎ", near)
+
+        hits = gateway.search_landmarks_nearby(
+            center, 2000, target_count=5, distance_tolerance_percent=15.0, max_calls=1
         )
         assert hits == []
 
@@ -413,5 +407,5 @@ class TestAppleMapsGatewaySearch:
         gateway._session.get.return_value = bad
 
         with pytest.raises(ExternalServiceError) as exc_info:
-            gateway.search_landmarks_nearby(center, 2000, target_count=1)
+            gateway.search_landmarks_nearby(center, 2000, target_count=1, max_calls=1)
         assert exc_info.value.service_name == "Apple Maps Server API"

--- a/backend/tests/app/infrastructure/gateways/test_apple_maps_gateway.py
+++ b/backend/tests/app/infrastructure/gateways/test_apple_maps_gateway.py
@@ -1,0 +1,411 @@
+"""Apple Maps Gateway / Auth / マッピングのテスト (HTTP はモック、ネットワーク無し)"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from requests.exceptions import HTTPError
+
+from app.domain.exceptions import ExternalServiceError
+from app.domain.value_objects import Coordinate
+from app.infrastructure.gateways.apple_maps_auth import (
+    AppleMapsCredentialsError,
+    AppleMapsTokenProvider,
+)
+from app.infrastructure.gateways.apple_maps_gateway_impl import (
+    CATEGORY_SEARCH_GENERIC_Q,
+    AppleMapsGatewayImpl,
+    circle_to_search_region,
+    distance_band_bounds,
+    format_search_region,
+    prefix_apple_place_id,
+)
+from app.infrastructure.gateways.apple_poi_category_mapping import (
+    GOOGLE_TYPE_TO_APPLE_POI_CATEGORY,
+    map_google_types_to_apple_poi_categories,
+)
+
+
+def _generate_es256_private_key_pem() -> str:
+    """テスト用の ES256 秘密鍵 PEM を生成する。"""
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem.decode("utf-8")
+
+
+@pytest.fixture
+def es256_pem() -> str:
+    """ES256 用の一時秘密鍵 PEM。"""
+    return _generate_es256_private_key_pem()
+
+
+@pytest.fixture
+def token_provider(es256_pem: str) -> AppleMapsTokenProvider:
+    """モック Session 付き TokenProvider。"""
+    session = MagicMock()
+    return AppleMapsTokenProvider(
+        team_id="TEAM12ABCD",
+        key_id="KEY12ABCDE",
+        private_key_pem=es256_pem,
+        base_url="https://maps-api.apple.test/v1",
+        session=session,
+    )
+
+
+class TestApplePoiCategoryMapping:
+    """Google → Apple カテゴリマッピング"""
+
+    def test_LANDMARKタイプがユニークなAppleカテゴリに畳み込まれること(self) -> None:
+        """複数 Google タイプが同一 Apple カテゴリへ重複なく畳み込まれる。"""
+        categories = map_google_types_to_apple_poi_categories()
+        assert "Park" in categories
+        assert "Museum" in categories
+        assert "Cafe" in categories
+        assert categories.count("Park") == 1
+
+    def test_ReligiousSiteがGoogleリストに無くても追加されること(self) -> None:
+        """神社・寺院向けに ReligiousSite を明示追加する。"""
+        categories = map_google_types_to_apple_poi_categories()
+        assert "ReligiousSite" in categories
+
+    def test_ギャップタイプが粗畳み込みされること(self) -> None:
+        """Apple に無い語彙は Spa / Hotel / Landmark へ寄せる。"""
+        assert GOOGLE_TYPE_TO_APPLE_POI_CATEGORY["public_bath"] == "Spa"
+        assert GOOGLE_TYPE_TO_APPLE_POI_CATEGORY["japanese_inn"] == "Hotel"
+        assert GOOGLE_TYPE_TO_APPLE_POI_CATEGORY["ferris_wheel"] == "Landmark"
+
+
+class TestBboxAndDistanceBand:
+    """bbox 近似と距離帯"""
+
+    def test_円をsearchRegionのbboxに近似できること(self) -> None:
+        """center+radius が north,east,south,west になる。"""
+        center = Coordinate(latitude=35.0, longitude=139.0)
+        north, east, south, west = circle_to_search_region(center, 1000.0)
+        assert north > 35.0 > south
+        assert east > 139.0 > west
+        assert format_search_region((north, east, south, west)).count(",") == 3
+
+    def test_距離帯の上下限がtoleranceどおりであること(self) -> None:
+        """±15% の距離帯を計算できる。"""
+        low, high = distance_band_bounds(2000.0, 15.0)
+        assert low == pytest.approx(1700.0)
+        assert high == pytest.approx(2300.0)
+
+    def test_place_idにappleプレフィックスが付くこと(self) -> None:
+        """Google place_id と衝突しないよう prefix する。"""
+        assert prefix_apple_place_id("I123") == "apple:I123"
+        assert prefix_apple_place_id("apple:I123") == "apple:I123"
+
+
+class TestAppleMapsTokenProvider:
+    """JWT / access token"""
+
+    def test_maps_auth_tokenがES256で署名されること(
+        self, token_provider: AppleMapsTokenProvider, es256_pem: str
+    ) -> None:
+        """maps_auth_token の header / claims / 署名を検証する。"""
+        token = token_provider.create_maps_auth_token(now=1_700_000_000)
+        header = jwt.get_unverified_header(token)
+        assert header["alg"] == "ES256"
+        assert header["kid"] == "KEY12ABCDE"
+        claims = jwt.decode(token, options={"verify_signature": False})
+        assert claims["iss"] == "TEAM12ABCD"
+        assert claims["scope"] == "server_api"
+        private_key = load_pem_private_key(es256_pem.encode(), password=None)
+        public_key = private_key.public_key()
+        jwt.decode(
+            token,
+            public_key,
+            algorithms=["ES256"],
+            options={"verify_exp": False},
+        )
+
+    def test_access_tokenをキャッシュして再取得しないこと(
+        self, token_provider: AppleMapsTokenProvider
+    ) -> None:
+        """有効期限内は /v1/token を再呼び出ししない。"""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "accessToken": "access-token-1",
+            "expiresInSeconds": 1800,
+        }
+        token_provider._session.get.return_value = mock_response
+
+        first = token_provider.get_access_token(now=1_000.0)
+        second = token_provider.get_access_token(now=1_100.0)
+        assert first == second == "access-token-1"
+        assert token_provider._session.get.call_count == 1
+
+    def test_期限切れ後はaccess_tokenを再取得すること(
+        self, token_provider: AppleMapsTokenProvider
+    ) -> None:
+        """skew を超えたら access token を更新する。"""
+        first_response = MagicMock()
+        first_response.raise_for_status = MagicMock()
+        first_response.json.return_value = {
+            "accessToken": "token-a",
+            "expiresInSeconds": 100,
+        }
+        second_response = MagicMock()
+        second_response.raise_for_status = MagicMock()
+        second_response.json.return_value = {
+            "accessToken": "token-b",
+            "expiresInSeconds": 1800,
+        }
+        token_provider._session.get.side_effect = [first_response, second_response]
+
+        assert token_provider.get_access_token(now=0.0) == "token-a"
+        assert token_provider.get_access_token(now=50.0) == "token-b"
+        assert token_provider._session.get.call_count == 2
+
+    def test_認証情報不足でCredentialsErrorになること(self, tmp_path: Path) -> None:
+        """必須 env が無いとき明確なエラーになる。"""
+        with pytest.raises(AppleMapsCredentialsError, match="APPLE_TEAM_ID"):
+            AppleMapsTokenProvider.from_env(
+                team_id=None,
+                key_id="KEY",
+                private_key_path=str(tmp_path / "missing.p8"),
+                backend_dir=tmp_path,
+            )
+
+
+class TestAppleMapsGatewaySearch:
+    """カテゴリ検索 / フォールバック / dedup"""
+
+    @pytest.fixture
+    def gateway(self, token_provider: AppleMapsTokenProvider) -> AppleMapsGatewayImpl:
+        """アクセストークン取得済みの Gateway。"""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "accessToken": "test-access",
+            "expiresInSeconds": 1800,
+        }
+        token_provider._session.get.return_value = mock_response
+        return AppleMapsGatewayImpl(
+            token_provider,
+            base_url="https://maps-api.apple.test/v1",
+            session=MagicMock(),
+            fallback_queries=("公園", "神社"),
+        )
+
+    def _point_at_distance(
+        self, center: Coordinate, distance_m: float, bearing_deg: float = 0.0
+    ) -> Coordinate:
+        """簡易: bearing 方向へ distance_m だけずらす (テスト用近似)。"""
+        delta_lat = distance_m / 111_320.0
+        radians = math.radians(bearing_deg)
+        lat = float(center.latitude) + delta_lat * math.cos(radians)
+        meters_per_degree_lng = 111_320.0 * math.cos(math.radians(float(center.latitude)))
+        lng = float(center.longitude) + (distance_m / meters_per_degree_lng) * math.sin(radians)
+        return Coordinate(latitude=lat, longitude=lng)
+
+    def test_カテゴリ検索で距離帯内のPOIが返ること(self, gateway: AppleMapsGatewayImpl) -> None:
+        """カテゴリ検索結果を距離帯で絞り、q 無しで呼ぶ。"""
+        center = Coordinate(latitude=35.232, longitude=139.107)
+        in_band = self._point_at_distance(center, 2000.0)
+        out_of_band = self._point_at_distance(center, 500.0)
+
+        search_response = MagicMock()
+        search_response.raise_for_status = MagicMock()
+        search_response.json.return_value = {
+            "results": [
+                {
+                    "id": "park-1",
+                    "name": "箱根公園",
+                    "poiCategory": "Park",
+                    "coordinate": {
+                        "latitude": in_band.latitude,
+                        "longitude": in_band.longitude,
+                    },
+                },
+                {
+                    "id": "cafe-near",
+                    "name": "近すぎるカフェ",
+                    "poiCategory": "Cafe",
+                    "coordinate": {
+                        "latitude": out_of_band.latitude,
+                        "longitude": out_of_band.longitude,
+                    },
+                },
+            ]
+        }
+        gateway._session.get.return_value = search_response
+
+        hits = gateway.search_landmarks_nearby(
+            center, 2000, target_count=1, distance_tolerance_percent=15.0
+        )
+        assert len(hits) == 1
+        assert hits[0].place_id == "apple:park-1"
+        assert hits[0].source == "category"
+        assert hits[0].display_name == "箱根公園"
+
+        first_params = gateway._session.get.call_args_list[0].kwargs["params"]
+        assert "includePoiCategories" in first_params
+        assert "q" not in first_params
+        assert first_params["resultTypeFilter"] == "Poi"
+        assert first_params["lang"] == "ja-JP"
+        assert first_params["limitToCountries"] == "JP"
+
+    def test_カテゴリ検索が400なら汎用qで再試行すること(
+        self, gateway: AppleMapsGatewayImpl
+    ) -> None:
+        """q 省略が拒否されたら汎用 q でリトライする。"""
+        center = Coordinate(latitude=35.0, longitude=139.0)
+        in_band = self._point_at_distance(center, 2000.0)
+
+        bad_response = MagicMock()
+        bad_response.status_code = 400
+        bad_response.text = "q is required"
+        http_error = HTTPError(response=bad_response)
+        bad_response.raise_for_status.side_effect = http_error
+
+        ok_response = MagicMock()
+        ok_response.raise_for_status = MagicMock()
+        ok_response.json.return_value = {
+            "results": [
+                {
+                    "id": "spot-1",
+                    "name": "スポットA",
+                    "poiCategory": "Park",
+                    "coordinate": {
+                        "latitude": in_band.latitude,
+                        "longitude": in_band.longitude,
+                    },
+                }
+            ]
+        }
+        gateway._session.get.side_effect = [bad_response, ok_response]
+
+        hits = gateway.search_landmarks_nearby(
+            center, 2000, target_count=1, distance_tolerance_percent=15.0
+        )
+        assert len(hits) == 1
+        second_params = gateway._session.get.call_args_list[1].kwargs["params"]
+        assert second_params["q"] == CATEGORY_SEARCH_GENERIC_Q
+
+    def test_件数不足時にクエリバッグへフォールバックすること(
+        self, gateway: AppleMapsGatewayImpl
+    ) -> None:
+        """カテゴリで足りないとき日本語クエリバッグを使う。"""
+        center = Coordinate(latitude=36.122, longitude=139.700)
+        in_band = self._point_at_distance(center, 2500.0)
+
+        empty_category = MagicMock()
+        empty_category.raise_for_status = MagicMock()
+        empty_category.json.return_value = {"results": []}
+
+        empty_query = MagicMock()
+        empty_query.raise_for_status = MagicMock()
+        empty_query.json.return_value = {"results": []}
+
+        query_hit = MagicMock()
+        query_hit.raise_for_status = MagicMock()
+        query_hit.json.return_value = {
+            "results": [
+                {
+                    "id": "shrine-1",
+                    "name": "久喜神社",
+                    "poiCategory": "ReligiousSite",
+                    "coordinate": {
+                        "latitude": in_band.latitude,
+                        "longitude": in_band.longitude,
+                    },
+                }
+            ]
+        }
+        gateway._session.get.side_effect = [empty_category, empty_query, query_hit]
+
+        hits = gateway.search_landmarks_nearby(
+            center, 2500, target_count=1, distance_tolerance_percent=15.0
+        )
+        assert len(hits) == 1
+        assert hits[0].source == "query"
+        assert hits[0].place_id == "apple:shrine-1"
+
+        query_params = gateway._session.get.call_args_list[2].kwargs["params"]
+        assert query_params["q"] == "神社"
+
+    def test_同一place_idはdedupされること(self, gateway: AppleMapsGatewayImpl) -> None:
+        """カテゴリとクエリで同じ id が出ても 1 件にまとめる。"""
+        center = Coordinate(latitude=35.232, longitude=139.107)
+        in_band = self._point_at_distance(center, 2000.0)
+        payload = {
+            "results": [
+                {
+                    "id": "dup-1",
+                    "name": "同じ場所",
+                    "poiCategory": "Park",
+                    "coordinate": {
+                        "latitude": in_band.latitude,
+                        "longitude": in_band.longitude,
+                    },
+                }
+            ]
+        }
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = payload
+        gateway._session.get.return_value = response
+
+        hits = gateway.search_landmarks_nearby(
+            center, 2000, target_count=5, distance_tolerance_percent=15.0
+        )
+        assert len(hits) == 1
+        assert hits[0].place_id == "apple:dup-1"
+
+    def test_認証なしでもモジュールimportとマッピングは動くこと(self) -> None:
+        """Apple 認証が無くてもマッピング単体は動く。"""
+        categories = map_google_types_to_apple_poi_categories(["park", "cafe"])
+        assert categories == ["Park", "Cafe", "ReligiousSite"]
+
+    def test_id欠落の結果はスキップすること(self, gateway: AppleMapsGatewayImpl) -> None:
+        """id が無い POI は採用しない。"""
+        center = Coordinate(latitude=35.0, longitude=139.0)
+        in_band = self._point_at_distance(center, 2000.0)
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "results": [
+                {
+                    "name": "IDなし",
+                    "coordinate": {
+                        "latitude": in_band.latitude,
+                        "longitude": in_band.longitude,
+                    },
+                }
+            ]
+        }
+        gateway._session.get.return_value = response
+        hits = gateway.search_landmarks_nearby(
+            center, 2000, target_count=1, distance_tolerance_percent=15.0
+        )
+        assert hits == []
+
+    def test_HTTPエラーがExternalServiceErrorになること(
+        self, gateway: AppleMapsGatewayImpl
+    ) -> None:
+        """検索 API の 500 をドメイン例外へ変換する。"""
+        center = Coordinate(latitude=35.0, longitude=139.0)
+        bad = MagicMock()
+        bad.status_code = 500
+        bad.text = "boom"
+        bad.raise_for_status.side_effect = HTTPError(response=bad)
+        gateway._session.get.return_value = bad
+
+        with pytest.raises(ExternalServiceError) as exc_info:
+            gateway.search_landmarks_nearby(center, 2000, target_count=1)
+        assert exc_info.value.service_name == "Apple Maps Server API"

--- a/backend/tests/app/infrastructure/gateways/test_apple_maps_gateway.py
+++ b/backend/tests/app/infrastructure/gateways/test_apple_maps_gateway.py
@@ -255,6 +255,8 @@ class TestAppleMapsGatewaySearch:
 
         first_params = gateway._session.get.call_args_list[0].kwargs["params"]
         assert "includePoiCategories" in first_params
+        assert "searchRegion" in first_params
+        assert "searchLocation" not in first_params
         assert "q" not in first_params
         assert first_params["resultTypeFilter"] == "Poi"
         assert first_params["lang"] == "ja-JP"
@@ -296,6 +298,8 @@ class TestAppleMapsGatewaySearch:
         assert len(hits) == 1
         second_params = gateway._session.get.call_args_list[1].kwargs["params"]
         assert second_params["q"] == CATEGORY_SEARCH_GENERIC_Q
+        assert "searchRegion" in second_params
+        assert "searchLocation" not in second_params
 
     def test_件数不足時にクエリバッグへフォールバックすること(
         self, gateway: AppleMapsGatewayImpl
@@ -338,6 +342,8 @@ class TestAppleMapsGatewaySearch:
 
         query_params = gateway._session.get.call_args_list[2].kwargs["params"]
         assert query_params["q"] == "神社"
+        assert "searchRegion" in query_params
+        assert "searchLocation" not in query_params
 
     def test_同一place_idはdedupされること(self, gateway: AppleMapsGatewayImpl) -> None:
         """カテゴリとクエリで同じ id が出ても 1 件にまとめる。"""

--- a/backend/tests/app/infrastructure/gateways/test_apple_maps_gateway.py
+++ b/backend/tests/app/infrastructure/gateways/test_apple_maps_gateway.py
@@ -24,6 +24,7 @@ from app.infrastructure.gateways.apple_maps_gateway_impl import (
     CULTURE_QUERY_BUCKET,
     OUTDOOR_QUERY_BUCKET,
     AppleMapsGatewayImpl,
+    AppleMapsHTTPError,
     build_stratified_query_bag,
     circle_to_search_region,
     distance_band_bounds,
@@ -243,6 +244,25 @@ class TestAppleMapsTokenProvider:
                 private_key_path=None,
             )
 
+    def test_accessToken欠落時はキー名のみ例外に含めること(
+        self, token_provider: AppleMapsTokenProvider
+    ) -> None:
+        """トークン JSON の値はログに載せない (キー一覧のみ)。"""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "expiresInSeconds": 1800,
+            "unexpectedSecret": "should-not-appear-in-message",
+        }
+        token_provider._session.get.return_value = mock_response
+
+        with pytest.raises(ExternalServiceError) as exc_info:
+            token_provider.get_access_token(now=1_000.0)
+        assert "accessToken" in exc_info.value.message
+        assert "keys=" in exc_info.value.message
+        assert "unexpectedSecret" in exc_info.value.message  # キー名は出る
+        assert "should-not-appear-in-message" not in exc_info.value.message
+
 
 class TestAppleMapsGatewaySearch:
     """層別クエリ / 早期停止 / ファンアウト / dedup"""
@@ -395,10 +415,10 @@ class TestAppleMapsGatewaySearch:
         )
         assert hits == []
 
-    def test_HTTPエラーがExternalServiceErrorになること(
+    def test_HTTPエラーがstatus_code付きAppleMapsHTTPErrorになること(
         self, gateway: AppleMapsGatewayImpl
     ) -> None:
-        """検索 API の 500 をドメイン例外へ変換する。"""
+        """検索 API の HTTP エラーは数値 status_code を保持する。"""
         center = Coordinate(latitude=35.0, longitude=139.0)
         bad = MagicMock()
         bad.status_code = 500
@@ -406,6 +426,38 @@ class TestAppleMapsGatewaySearch:
         bad.raise_for_status.side_effect = HTTPError(response=bad)
         gateway._session.get.return_value = bad
 
-        with pytest.raises(ExternalServiceError) as exc_info:
+        with pytest.raises(AppleMapsHTTPError) as exc_info:
             gateway.search_landmarks_nearby(center, 2000, target_count=1, max_calls=1)
         assert exc_info.value.service_name == "Apple Maps Server API"
+        assert exc_info.value.status_code == 500
+
+    def test_HTTP400もstatus_codeで判定できること(self, gateway: AppleMapsGatewayImpl) -> None:
+        """400 もメッセージ文字列ではなく status_code == 400 で分かる。"""
+        center = Coordinate(latitude=35.0, longitude=139.0)
+        bad = MagicMock()
+        bad.status_code = 400
+        # 本文に "HTTP 400" が含まれても、判定は status_code 側を使う前提
+        bad.text = "other status mention: HTTP 400 is not how we classify"
+        bad.raise_for_status.side_effect = HTTPError(response=bad)
+        gateway._session.get.return_value = bad
+
+        with pytest.raises(AppleMapsHTTPError) as exc_info:
+            gateway.search_landmarks_nearby(center, 2000, target_count=1, max_calls=1)
+        assert exc_info.value.status_code == 400
+        assert isinstance(exc_info.value, ExternalServiceError)
+
+    def test_HTTPエラー本文は例外メッセージで切り詰められること(
+        self, gateway: AppleMapsGatewayImpl
+    ) -> None:
+        """巨大なレスポンス本文を無制限に例外へ載せない。"""
+        center = Coordinate(latitude=35.0, longitude=139.0)
+        bad = MagicMock()
+        bad.status_code = 502
+        bad.text = "x" * 2000
+        bad.raise_for_status.side_effect = HTTPError(response=bad)
+        gateway._session.get.return_value = bad
+
+        with pytest.raises(AppleMapsHTTPError) as exc_info:
+            gateway.search_landmarks_nearby(center, 2000, target_count=1, max_calls=1)
+        assert "truncated" in exc_info.value.message
+        assert len(exc_info.value.message) < 500

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -45,6 +45,79 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -168,6 +241,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/951032a3bf22a5697c83183fb6294a4843772947a70e616c57b3ff5f522e/cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41", size = 3989258, upload-time = "2026-07-31T14:23:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9a/02ffe35b2853d121689871eb5dce862092562b3a1ed5cc98f1aaed441506/cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269", size = 3816291, upload-time = "2026-07-31T14:24:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
@@ -281,6 +404,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -355,6 +487,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -482,6 +628,7 @@ dependencies = [
     { name = "geopy" },
     { name = "injector" },
     { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "tenacity" },
@@ -501,6 +648,7 @@ requires-dist = [
     { name = "geopy", specifier = ">=2.4.1" },
     { name = "injector", specifier = ">=0.23.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "tenacity", specifier = ">=9.1.2" },

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -32,6 +32,26 @@
 
 基本的に、GCPで生成するシークレット（APIキーなど）とGCP以外のシークレット（GitHub AppsのSecretなど）の2つがある。GCPのシークレットはTerraformでシークレットを作成してSecret Managerに登録することでGCP上のリソースで利用できる。GCP以外のシークレットは`TF_VAR_{xxx}`の環境変数をGitHubリポジトリのSecretに設定して、GitHub Actionsで`terrafrom apply`する際に変数としてTerraformに注入する。
 
+#### Apple Maps 秘密鍵 (目的地ランドマーク検索)
+
+Terraform は Secret Manager のコンテナ `apple-maps-private-key` だけを作る (PEM は git / tfvars に入れない)。Cloud Run には `APPLE_MAPS_PRIVATE_KEY` として注入する。Team ID / Key ID はプレーンな環境変数 (`apple_team_id` / `apple_maps_key_id`、例は `secrets.auto.tfvars.example`)。
+
+初回 (または鍵ローテ時) にバージョンを追加する:
+
+```bash
+# 開発
+gcloud secrets versions add apple-maps-private-key \
+  --data-file=AuthKey_XXXXXXXXXX.p8 \
+  --project=snampo-480404
+
+# 本番
+gcloud secrets versions add apple-maps-private-key \
+  --data-file=AuthKey_XXXXXXXXXX.p8 \
+  --project=snampo-prod
+```
+
+Cloud Run が参照する前に、少なくとも 1 バージョンが必要。
+
 ## 初期セットアップ
 
 ### 権限の確認とGCPの認証

--- a/terraform/env/dev/main.tf
+++ b/terraform/env/dev/main.tf
@@ -27,6 +27,9 @@ module "snampo_dev" {
   project_env  = local.env
   project_id   = local.project_id
   project_name = local.project_name
+  # Apple Maps (目的地検索)。秘密鍵 PEM は Secret Manager へ別途 versions add。
+  apple_team_id     = var.apple_team_id
+  apple_maps_key_id = var.apple_maps_key_id
   # 有効化するAPI
   api_list = [
     "cloudbuild.googleapis.com", # TODO: GitHub Actionsに移行するため削除予定。
@@ -47,4 +50,16 @@ module "snampo_dev" {
       package_name_prefixes = ["snampo"]
     },
   ]
+}
+
+variable "apple_team_id" {
+  type        = string
+  description = "Apple Developer Team ID"
+  default     = ""
+}
+
+variable "apple_maps_key_id" {
+  type        = string
+  description = "Apple Maps Key ID"
+  default     = ""
 }

--- a/terraform/env/dev/secrets.auto.tfvars.example
+++ b/terraform/env/dev/secrets.auto.tfvars.example
@@ -8,3 +8,9 @@ discord_role_id = "000000000000000000"
 
 # Discord チャンネルの Webhook URL (チャンネル設定 → 連携サービス → ウェブフック)
 discord_webhook_url = "https://discord.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN"
+
+# Apple Maps Server API (目的地ランドマーク検索)
+# Team ID / Key ID は識別子のみ。秘密鍵 PEM はここに書かず Secret Manager へ:
+#   gcloud secrets versions add apple-maps-private-key --data-file=AuthKey_XXXX.p8 --project=snampo-480404
+apple_team_id     = "YOURTEAMID0"
+apple_maps_key_id = "YOURKEYID00"

--- a/terraform/env/prod/main.tf
+++ b/terraform/env/prod/main.tf
@@ -26,6 +26,9 @@ module "snampo_prod" {
   project_env  = local.env
   project_id   = local.project_id
   project_name = local.project_name
+  # Apple Maps (目的地検索)。秘密鍵 PEM は Secret Manager へ別途 versions add。
+  apple_team_id     = var.apple_team_id
+  apple_maps_key_id = var.apple_maps_key_id
   # グループの権限
   group_iam_config = [
     {
@@ -33,4 +36,16 @@ module "snampo_prod" {
       roles = ["roles/viewer"]
     },
   ]
+}
+
+variable "apple_team_id" {
+  type        = string
+  description = "Apple Developer Team ID"
+  default     = ""
+}
+
+variable "apple_maps_key_id" {
+  type        = string
+  description = "Apple Maps Key ID"
+  default     = ""
 }

--- a/terraform/env/prod/secrets.auto.tfvars.example
+++ b/terraform/env/prod/secrets.auto.tfvars.example
@@ -1,0 +1,9 @@
+# 本番用シークレット設定の例
+# このファイルをコピーして secrets.auto.tfvars を作成し、実際の値を入力
+# (または CI で TF_VAR_apple_team_id / TF_VAR_apple_maps_key_id を注入)
+
+# Apple Maps Server API (目的地ランドマーク検索)
+# 秘密鍵 PEM は tfvars に入れない。Secret Manager へ out-of-band で追加:
+#   gcloud secrets versions add apple-maps-private-key --data-file=AuthKey_XXXX.p8 --project=snampo-prod
+apple_team_id     = "YOURTEAMID0"
+apple_maps_key_id = "YOURKEYID00"

--- a/terraform/modules/common/main.tf
+++ b/terraform/modules/common/main.tf
@@ -236,6 +236,23 @@ locals {
   )
 }
 
+# Apple Maps 秘密鍵 (PEM)。バージョンは out-of-band で追加する:
+#   gcloud secrets versions add apple-maps-private-key --data-file=AuthKey_XXXX.p8 --project=<project_id>
+resource "google_secret_manager_secret" "apple_maps_private_key" {
+  project   = var.project_id
+  secret_id = "apple-maps-private-key"
+
+  replication {
+    user_managed {
+      replicas {
+        location = var.location
+      }
+    }
+  }
+
+  depends_on = [module.project_services]
+}
+
 module "artifact_registry" {
   source     = "GoogleCloudPlatform/artifact-registry/google"
   version    = "~> 0.8"
@@ -283,12 +300,24 @@ locals {
           {
             name  = "ENV"
             value = var.project_env
-          }
+          },
+          {
+            name  = "APPLE_TEAM_ID"
+            value = var.apple_team_id
+          },
+          {
+            name  = "APPLE_MAPS_KEY_ID"
+            value = var.apple_maps_key_id
+          },
         ]
         env_secret = [
           {
             name      = "GOOGLE_API_KEY"
             secret_id = "backend-api-key"
+          },
+          {
+            name      = "APPLE_MAPS_PRIVATE_KEY"
+            secret_id = google_secret_manager_secret.apple_maps_private_key.secret_id
           },
         ] # ここで指定できるのは、APIキーかシークレットのID
         port = 80
@@ -304,7 +333,7 @@ locals {
 
 module "cloud_run_service" {
   source     = "../gcp/cloud-run"
-  depends_on = [module.iam_members, module.secret_manager]
+  depends_on = [module.iam_members, module.secret_manager, google_secret_manager_secret.apple_maps_private_key]
   for_each = {
     for conf in local.cloud_run_service_config_list : conf.service_name => {
       service_account = conf.service_account

--- a/terraform/modules/common/variables.tf
+++ b/terraform/modules/common/variables.tf
@@ -101,3 +101,17 @@ variable "cloud_run_service_configs" {
 
   default = []
 }
+
+# Apple Maps Server API (目的地ランドマーク検索)
+# 秘密鍵 PEM は tfvars に入れず、Secret Manager へ out-of-band で versions add する。
+variable "apple_team_id" {
+  type        = string
+  description = "Apple Developer Team ID (Cloud Run APPLE_TEAM_ID)"
+  default     = ""
+}
+
+variable "apple_maps_key_id" {
+  type        = string
+  description = "Apple Maps Key ID (Cloud Run APPLE_MAPS_KEY_ID)"
+  default     = ""
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

#235: **Google Nearby / 目的地ランドマーク検索のみ** を Apple Maps Server API に置き換えます。Directions / Street View / photos / Roads / 中間地点検索は Google のままです (`/v1/directions` に waypoints が無いためルート生成は差し替えません)。

### 検索戦略

1. `searchRegion` bbox (目標距離 × 1.15) + 日本語 `q` (層別シャッフル)
2. 先頭 3 件: outdoor / culture / casual 各バケットから 1 つ → 残りをシャッフル
3. ±`LANDMARK_DISTANCE_TOLERANCE_PERCENT` で距離帯フィルタ、`apple:` 付き id で dedup
4. 不足時は円周ファンアウト (`searchLocation` のみ、`searchRegion` と同時指定しない)
5. HTTP 予算は `LANDMARK_SEARCH_MAX_CALLS` (8)。シードは中心 lat/lng + 半径で再現可能

### 本番配線

- `LandmarkSearchService` → `AppleMapsGateway`
- `GenerateRouteUseCase` の random 目的地検索が Apple 経由に
- DI (`container.py`) で `AppleMapsGateway` を bind
- 中間地点は引き続き `GoogleMapsGateway.search_landmarks_nearby`

### 認証 (local / Cloud Run)

- `APPLE_TEAM_ID` / `APPLE_MAPS_KEY_ID` (プレーン env)
- 秘密鍵: `APPLE_MAPS_PRIVATE_KEY` (PEM、Cloud Run Secret Manager 優先) → なければ `APPLE_MAPS_PRIVATE_KEY_PATH` (.p8)
- Terraform: `apple-maps-private-key` シークレット作成のみ (PEM は tfvars に入れない)。バージョンは out-of-band で `gcloud secrets versions add`

## テスト

- [x] `uv run pytest` (179 passed、モック HTTP)
- [x] 層別順序・早期停止・ファンアウト・PEM env・max_calls
- [ ] 実鍵で probe / ルート生成を確認
- [ ] Secret Manager に PEM バージョン追加後、Cloud Run で認証確認

```bash
cd backend
uv run python scripts/probe_apple_maps_search.py --fixture hakone --json
```

## 備考

- オペレータ手順: `terraform/README.md` の「Apple Maps 秘密鍵」節
- `.env.example` / `secrets.auto.tfvars.example` に Team ID・Key ID の例あり (PEM は書かない)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96246314-108b-4dc4-8878-f6e463119ca7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96246314-108b-4dc4-8878-f6e463119ca7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Apple Maps Server API による周辺ランドマーク検索に対応しました。
  * カテゴリ検索、検索結果不足時の追加検索、距離フィルタリング、重複除去を利用できます。
  * Apple Maps の認証情報を環境変数と秘密鍵ファイルから設定できるようになりました。
  * 検索結果を検証するためのプローブツールを追加しました。

* **改善**
  * Apple Maps のカテゴリを既存の地点カテゴリへ自動変換できるようになりました。
  * 認証トークンをキャッシュし、期限に応じて自動更新します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->