### PR TITLE
ci: App Store Connect連携名を Codemagic に更新

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -6,7 +6,7 @@ workflows:
     instance_type: mac_mini_m2
     working_directory: frontend
     integrations:
-      app_store_connect: Publisher  # Code MagicのWebサイトで設定したKeyの名前
+      app_store_connect: Codemagic  # Code MagicのWebサイトで設定したKeyの名前
     environment:
       flutter: stable
       xcode: latest


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- Codemagic Personal に残っている App Store Connect API キー名に合わせるため、`deploy-ios-dev` の `integrations.app_store_connect` を `Publisher` から `Codemagic` に変更
- workflow / signing / scripts / publishing など他の設定は変更なし

## テスト
- [ ] Codemagic の `deploy-ios-dev` で App Store Connect 連携名 `Codemagic` が解決されること
- [ ] `codemagic.yaml` の差分が当該1行のみであること

## 備考
- 近傍コメントは `Publisher` を含んでいなかったため文言変更なし

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0e58419-a776-499c-b7d8-854e340f4791?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0e58419-a776-499c-b7d8-854e340f4791&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

